### PR TITLE
Fix support for ROCm 7

### DIFF
--- a/ggml/src/ggml-cuda/cross-ring-interleave.cu
+++ b/ggml/src/ggml-cuda/cross-ring-interleave.cu
@@ -178,7 +178,7 @@ extern "C" bool dflash_cross_ring_gpu_write_d2d(
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (attr.type != cudaMemoryTypeDevice || attr.device != ring->device) {
         return false;
     }
@@ -253,7 +253,7 @@ extern "C" bool dflash_rebuild_conv_state(
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (r_attr.type != cudaMemoryTypeDevice || qkv_attr.type != cudaMemoryTypeDevice ||
             r_attr.device != qkv_attr.device) {
         return false;
@@ -288,7 +288,7 @@ extern "C" bool dflash_cuda_copy_d2d(void * dst, const void * src, size_t size) 
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (dst_attr.type != cudaMemoryTypeDevice || src_attr.type != cudaMemoryTypeDevice ||
             dst_attr.device != src_attr.device) {
         return false;
@@ -315,7 +315,7 @@ extern "C" bool dflash_cuda_prepare_ptr(const void * ptr) {
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (attr.type != cudaMemoryTypeDevice) {
         return false;
     }
@@ -345,7 +345,7 @@ extern "C" bool dflash_cuda_synchronize_ptr(const void * ptr) {
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (attr.type != cudaMemoryTypeDevice) {
         return false;
     }
@@ -418,7 +418,7 @@ extern "C" void dflash_cross_ring_gpu_set_tensor(
         cudaGetLastError();
     }
 
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     const bool dst_is_device = dst_err == cudaSuccess && dst_attr.type == cudaMemoryTypeDevice;
     const bool src_is_device = src_err == cudaSuccess && src_attr.type == cudaMemoryTypeDevice;
 #else
@@ -456,7 +456,7 @@ extern "C" bool dflash_kv_cache_write_d2d(
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (ring_attr.type != cudaMemoryTypeDevice || src_attr.type != cudaMemoryTypeDevice ||
             ring_attr.device != src_attr.device) {
         return false;
@@ -528,7 +528,7 @@ extern "C" bool dflash_kv_cache_append_d2d(
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (cache_attr.type != cudaMemoryTypeDevice || src_attr.type != cudaMemoryTypeDevice ||
             cache_attr.device != src_attr.device) {
         return false;
@@ -649,7 +649,7 @@ extern "C" bool dflash_kv_cache_interleave(
         cudaGetLastError();
         return false;
     }
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
     if (ring_attr.type != cudaMemoryTypeDevice || stage_attr.type != cudaMemoryTypeDevice ||
             ring_attr.device != stage_attr.device) {
         return false;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3147,7 +3147,7 @@ static void ggml_cuda_log_nonlocal_src_buffer(
         cudaError_t err = cudaPointerGetAttributes(&attr, data);
         if (err == cudaSuccess) {
             ptr_device = attr.device;
-#if CUDART_VERSION >= 10000
+#if CUDART_VERSION >= 10000 || defined(GGML_USE_HIP)
             switch (attr.type) {
 #else
             switch (attr.memoryType) {

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -99,6 +99,11 @@
 #define cudaMemGetInfo hipMemGetInfo
 #define cudaOccupancyMaxPotentialBlockSize hipOccupancyMaxPotentialBlockSize
 #define cudaSetDevice hipSetDevice
+#define cudaPointerAttributes hipPointerAttribute_t
+#define cudaPointerGetAttributes hipPointerGetAttributes
+#define cudaMemoryTypeDevice hipMemoryTypeDevice
+#define cudaMemoryTypeHost hipMemoryTypeHost
+#define cudaMemoryTypeManaged hipMemoryTypeManaged
 #define cuDeviceGet hipDeviceGet
 #define CUdevice hipDevice_t
 #define CUdeviceptr hipDeviceptr_t

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -80,10 +80,8 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-q4_0-q4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-bf16-bf16.cu)
-    if (WIN32)
-        file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-vec-instance-*turbo*.cu")
-        list(APPEND GGML_SOURCES_ROCM ${SRCS})
-    endif()
+    file(GLOB   SRCS "../ggml-cuda/template-instances/fattn-vec-instance-*turbo*.cu")
+    list(APPEND GGML_SOURCES_ROCM ${SRCS})
 endif()
 
 ggml_add_backend_library(ggml-hip


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This fixes a regression that seems to stem from https://github.com/Anbeeld/beellama.cpp/commit/a1d3989d0f836e8bef04ac5ee0aeb07707b4a78f and https://github.com/Anbeeld/beellama.cpp/commit/90bd5ea81edb9af5ee25c9572884b8ce53ef7e11 where HIP support wasn't implemented correctly.

Namely, HIP declares `attr.type` rather than `attr.memoryType`, so you would get a build failure on a ROCm-enabled build without `|| defined(GGML_USE_HIP)`.

Additionally, a bunch of `#define`s were missing from `ggml/src/ggml-cuda/vendors/hip.h`, again causing a build failure when ROCm-enabled.

Finally, for a reason that eludes me, we had a `if (WIN32)` guard in `ggml/src/ggml-hip/CMakeLists.txt`. These files should be included regardless of OS. The commit https://github.com/Anbeeld/beellama.cpp/commit/a1d3989d0f836e8bef04ac5ee0aeb07707b4a78f simply states "add win32 guard to preserve behavior on linux", but everything works fine with these patches, so idk. Maybe something's beyond me here 😅

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
  DeepWiki was used to find the source of the problem. Some of the code provided comes from DeepWiki, but I have found the CMakeLists.txt fix myself and found all the areas that needed to have `|| defined(GGML_USE_HIP)` added. I also tested that it Works on My Machine™️

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
