### PR TITLE
fix: DFlash GPU ring hang with turbo4 — sync ggml backend after decode

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4807,6 +4807,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
         ggml_status status;
         const int64_t t_dflash_decode_start_us = dflash_capture && dflash_capture->profile ? ggml_time_us() : 0;
         const auto * res = process_ubatch(ubatch, LLM_GRAPH_TYPE_DECODER, mctx.get(), status);
+        // DFlash: synchronize backends before ring_write reads GPU-rendered
+        // hidden tensors via cudaStreamPerThread (different stream than ggml's
+        // private CUDA stream, so no implicit ordering)
+        if (dflash_capture) {
+            ggml_backend_sched_synchronize(sched.get());
+        }
         if (dflash_capture && dflash_capture->profile && t_dflash_decode_start_us != 0) {
             dflash_capture->profile_decode_us += ggml_time_us() - t_dflash_decode_start_us;
         }


### PR DESCRIPTION
## Summary

DFlash GPU ring (`GGML_DFLASH_GPU_RING=1`) hangs during prompt processing when combined with turbo4 KV cache (`--cache-type-k turbo4`). The hang occurs in `flush_prefill()` → `ring_write()` → `llama_get_layer_hidden()` → `ctx->synchronize()` on the second decode ubatch.

Related to #15 (DFlash stream ordering root cause) and #16 (GPU ring crash in same code path — different symptom).

## Root Cause

The ggml CUDA backend uses a **private per-context stream** (`cuda_ctx->stream()`) for graph compute, but tensor read-back operations (`ggml_backend_cuda_buffer_get_tensor`) and DFlash GPU ring operations (`dflash_cross_ring_gpu_write_d2d`) use `cudaStreamPerThread` — a **different stream** with no implicit ordering.

When DFlash GPU capture is active (`dflash_graph_hidden_ready` true):
1. The eval callback is nullified — graph compute takes the non-callback path in `ggml_backend_sched_compute_splits`, which launches asynchronously without synchronizing
2. `process_ubatch()` returns while the private stream is still in-flight
3. `flush_prefill()` → `ring_write()` reads hidden tensors via `llama_get_layer_hidden()` → `ctx->synchronize()`, which calls `cudaStreamSynchronize` on the private stream
4. With turbo4, the graph may embed `cudaStreamWaitEvent` in the private stream that waits for events `cudaStreamPerThread` would record during D2D copies — creating a circular dependency that deadlocks

## Fix

One-line addition (with comment): `ggml_backend_sched_synchronize(sched.get())` guarded by `if (dflash_capture)` after `process_ubatch()` in `decode()`.

This ensures the ggml backend's private stream drains before any `cudaStreamPerThread` work begins, breaking the circular dependency.

## Testing

- 100% draft acceptance (7/7) with `GGML_DFLASH_GPU_RING=1` + turbo4
- Spec cycle: draft=6-14ms, verify=48-58ms, total=55-75ms
- Zero impact on non-DFlash contexts (guarded by `dflash_capture`)
- No regression with `GGML_DFLASH_GPU_RING=0` (CPU ring)