### PR TITLE
fix: include --spec-draft-ctx-size in DFlash arg\_passed check

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1032,7 +1032,7 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
             };
             const bool b_passed   = arg_passed({"-b", "--batch-size"});
             const bool ub_passed  = arg_passed({"-ub", "--ubatch-size"});
-            const bool cd_passed  = arg_passed({"-cd", "--ctx-size-draft"});
+            const bool cd_passed  = arg_passed({"-cd", "--ctx-size-draft", "--spec-draft-ctx-size"});
 
             if (!cd_passed && params.speculative.draft.n_ctx == 0) {
                 LOG_INF("dflash: setting -cd to 256 (drafter doesn't need the full main ctx; pass -cd N to override)\n");


### PR DESCRIPTION
## Problem

The `arg\_passed` check for DFlash draft ctx size only looked for `-cd` and `--ctx-size-draft`, missing `--spec-draft-ctx-size` which is registered as an alias in the help text and arg registration.

This caused the DFlash defaults logic to treat `--spec-draft-ctx-size` as if the flag was not passed, leading to incorrect default overrides and a measurable performance regression (340 → 300 tok/s in testing).

## Root cause

Line 1035 of `common/arg.cpp`:

```cpp
const bool cd_passed = arg_passed({"-cd", "--ctx-size-draft"});
```

While the arg registration on line 3916 lists all three aliases:

```cpp
{"--spec-draft-ctx-size", "-cd", "--ctx-size-draft"}
```

When `--spec-draft-ctx-size` is used, `params.speculative.draft.n_ctx` is set correctly, but `cd\_passed` remains `false`, causing downstream DFlash logic to apply unwanted defaults.

## Fix

Add `--spec-draft-ctx-size` to the `arg\_passed` check so all three aliases are recognized equivalently.