### PR TITLE
fix(cuda): increase argmax topk kernel limit from 32 to 64

### DIFF
--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -237,8 +237,8 @@ static __global__ void topk_f32(
 
     // Per-thread top-K heap (min-heap: smallest score at index 0)
     // Max K=32, stored in registers
-    float  heap_val[32];
-    int32_t heap_idx[32];
+    float  heap_val[64];
+    int32_t heap_idx[64];
     for (int i = 0; i < K; i++) {
         heap_val[i] = -FLT_MAX;
         heap_idx[i] = -1;
@@ -527,7 +527,7 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int cub_mode = ggml_cuda_dflash_cub_topk_mode();
     const bool use_cub_topk =
         K > 1 && !output_logprob && seed == 0 &&
-        (K > 32 || cub_mode == 1 || (cub_mode < 0 && nrows > 32));
+        (K > 64 || cub_mode == 1 || (cub_mode < 0 && nrows > 32));
     if (ggml_cuda_dflash_argmax_profile_enabled() && K > 1) {
         GGML_LOG_INFO("%s: dflash argmax profile path=%s K=%d nrows=%" PRId64
                 " vocab=%" PRId64 " temp=%.3f seed=%" PRIu64 " output_logprob=%d cub_mode=%d\n",
@@ -554,7 +554,7 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     if (K == 1) {
         argmax_f32<<<blocks_num, blocks_dim, 0, stream>>>(src0_d, dst_d, ne00, nrows, inv_temp, seed, output_logprob);
     } else {
-        GGML_ASSERT(K <= 32);
+        GGML_ASSERT(K <= 64);
         // Shared memory: K * n_warps floats + K * n_warps ints + 2 * n_warps floats (softmax)
         const int n_warps = (int)(num_threads / WARP_SIZE);
         const size_t smem_size = K * n_warps * (sizeof(float) + sizeof(int32_t)) + 2 * n_warps * sizeof(float);


### PR DESCRIPTION
## Summary

- Increases the custom `topk_f32` CUDA kernel limit from K ≤ 32 to K ≤ 64 by expanding the fixed-size register arrays
- Raises the CUB TopK auto-fallback threshold from K > 32 to K > 64 so the custom path covers the full `top_k=64` range

## Problem

On CUDA 12.x / pre-CCCL 3.2 Linux builds, the CUB TopK fallback (`GGML_CUDA_DFLASH_CUB_TOP_K_AVAILABLE`) is unavailable because it requires CCCL ≥ 3.2. The custom `topk_f32` kernel is the only path, and it has a hardcoded K ≤ 32 limit.

The Gemma 4 GGUF bakes `general.sampling.top_k = 64` into its metadata. The DFlash reduced verifier picks this up and passes K=64 to the target model's verification logits, which hits:

```
argmax.cu:557: GGML_ASSERT(K <= 32) failed
```

This crashes the server on the first inference request with any Gemma 4 model + DFlash on CUDA 12.x builds.

## Fix

- `heap_val[32]` / `heap_idx[32]` → `heap_val[64]` / `heap_idx[64]` (register arrays, +256 bytes per thread)
- `GGML_ASSERT(K <= 32)` → `GGML_ASSERT(K <= 64)`
- CUB auto-threshold: `K > 32` → `K > 64`

Shared memory at K=64, 32 warps: ~16 KB — well within the 48 KB default limit. Register pressure increase is modest and causes no issues on tested hardware (RTX 5090, RTX 3090).

## Test plan

- [x] Build succeeds on CUDA 12.x (GCC, Linux) with `GGML_CUDA_FA=ON`, `GGML_CUDA_FA_ALL_QUANTS=ON`
- [x] Launch Gemma 4 31B + DFlash draft model with default sampling (top_k=64 from metadata) and verify first inference completes without `GGML_ASSERT`
- [x] Run Qwen 3.6 27B + DFlash (top_k=20) to verify no regression on K ≤ 32 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)