### PR TITLE
fix(hip): Wave64 warp shuffle type mismatch

### DIFF
--- a/ggml/src/ggml-cuda/fwht.cu
+++ b/ggml/src/ggml-cuda/fwht.cu
@@ -29,7 +29,7 @@ __global__ void fwht_cuda(const float * src, float * dst, const int64_t n_rows, 
 #pragma unroll
         for (int j = 0; j < el_w; j++) {
             const float val  = reg[j];
-            const float val2 = __shfl_xor_sync(0xFFFFFFFF, val, h, warp_size);
+            const float val2 = __shfl_xor_sync(0xFFFFFFFFULL, val, h, warp_size);
 
             reg[j] = (lane & h) == 0 ? val + val2 : val2 - val;
         }

--- a/ggml/src/ggml-cuda/mma.cuh
+++ b/ggml/src/ggml-cuda/mma.cuh
@@ -736,7 +736,7 @@ namespace ggml_cuda_mma {
             int i = threadIdx.x / 16;
             tmp[i] = tile_float.x[l];
             i ^= 1;
-            tmp[i] = __shfl_xor_sync(0xFFFFFFFF, tile_float.x[l], 16, WARP_SIZE);
+            tmp[i] = __shfl_xor_sync(0xFFFFFFFFULL, tile_float.x[l], 16, WARP_SIZE);
             ret.x[l] = make_half2(tmp[0], tmp[1]);
         }
         return ret;


### PR DESCRIPTION
## Overview

This PR fixes a compiler type mismatch on AMD ROCm/HIP systems when building for **Wave64** architectures (GCN, CDNA, or RDNA targets compiled in Wave64 mode). 

It appends the missing `ULL` (unsigned long long) suffix to two hardcoded warp sync masks in `fwht.cu` and `mma.cuh`, converting `0xFFFFFFFF` to `0xFFFFFFFFULL`. This matches the established `ggml-cuda` convention used throughout the rest of the repository and prevents compilation failures due to strict 64-bit mask type matching on Wave64 targets.

## Additional information

This change brings these two outliers in line with standard conventions already used everywhere else in the codebase (such as in `argmax.cu`, `common.cuh`, and other sections of `mma.cuh`), which already use `0xFFFFFFFFULL` universally.

It is fully backward-compatible with 32-bit NVIDIA CUDA and AMD Wave32 compilers, which implicitly downcast the literal safely.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  - How AI was used: Assisted in researching the Wave64 type signature requirements under HIP/ROCm and verifying matching conventions in the existing codebase.
