### PR TITLE
[codex] Fix HIP FA route fallback for D=256 MTP decode

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -1852,6 +1852,7 @@ struct ggml_cuda_fattn_route_plan {
     bool allow_vec;
     bool unsafe_vec_after_turbo_v_decode;
     best_fattn_kernel kernel;
+    const char * none_reason;
 };
 
 static inline bool ggml_cuda_fattn_can_force_hip_tile_fallback(
@@ -1869,7 +1870,7 @@ static inline bool ggml_cuda_fattn_can_force_hip_tile_fallback(
         return false;
     }
 
-    if (mask && mask->ne[2] != 1) {
+    if (K->ne[1] % FATTN_KQ_STRIDE != 0) {
         return false;
     }
 
@@ -1893,6 +1894,7 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
     const ggml_tensor * Q = dst->src[0];
     const ggml_tensor * K = dst->src[1];
     const ggml_tensor * V = dst->src[2];
+    const ggml_tensor * mask = dst->src[3];
 
     ggml_cuda_fattn_route_plan plan = {};
 
@@ -1988,26 +1990,50 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
         ggml_cuda_fattn_effective_vec_shape_unsafe(Q, &K_eff, &V_eff);
 
     plan.allow_vec = !plan.unsafe_vec_after_turbo_v_decode;
+    plan.none_reason = nullptr;
 
     plan.kernel = ggml_cuda_get_best_fattn_kernel(device, &dst_eff, plan.allow_vec);
+
+    if (plan.kernel == BEST_FATTN_KERNEL_NONE) {
+        if (V_eff.ne[0] != K_eff.ne[0]) {
+            plan.none_reason = "K/V head dim mismatch";
+        } else if (mask && mask->ne[2] != 1) {
+            plan.none_reason = "mask ne[2] != 1";
+        } else if (K_eff.ne[1] % FATTN_KQ_STRIDE != 0) {
+            plan.none_reason = "K sequence length is not FATTN_KQ_STRIDE padded";
+        } else if (plan.effective_type_K != GGML_TYPE_F16 || plan.effective_type_V != GGML_TYPE_F16) {
+            plan.none_reason = "unsupported effective K/V type pair";
+        } else {
+            plan.none_reason = "kernel selector returned NONE";
+        }
+    }
 
     if (plan.kernel == BEST_FATTN_KERNEL_NONE &&
         ggml_cuda_fattn_can_force_hip_tile_fallback(Q, &K_eff, &V_eff, dst->src[3], plan)) {
         plan.kernel = BEST_FATTN_KERNEL_TILE;
+        plan.none_reason = "forced HIP tile fallback";
 
         if (ggml_cuda_fattn_route_debug_enabled()) {
             fprintf(stderr,
                 "CUDA_FA_ROUTE_FALLBACK "
                 "device=%d forcing=HIP_TILE "
                 "Q=[%lld,%lld,%lld,%lld] "
+                "mask=%s mask_shape=[%lld,%lld,%lld,%lld] "
                 "Keff=%s Veff=%s "
-                "Kshape=[%lld,%lld,%lld,%lld] Vshape=[%lld,%lld,%lld,%lld]\n",
+                "Kshape=[%lld,%lld,%lld,%lld] Vshape=[%lld,%lld,%lld,%lld] "
+                "reason=%s\n",
                 device,
                 (long long) Q->ne[0], (long long) Q->ne[1], (long long) Q->ne[2], (long long) Q->ne[3],
+                mask ? "yes" : "no",
+                mask ? (long long) mask->ne[0] : -1LL,
+                mask ? (long long) mask->ne[1] : -1LL,
+                mask ? (long long) mask->ne[2] : -1LL,
+                mask ? (long long) mask->ne[3] : -1LL,
                 ggml_type_name(plan.effective_type_K),
                 ggml_type_name(plan.effective_type_V),
                 (long long) K_eff.ne[0], (long long) K_eff.ne[1], (long long) K_eff.ne[2], (long long) K_eff.ne[3],
-                (long long) V_eff.ne[0], (long long) V_eff.ne[1], (long long) V_eff.ne[2], (long long) V_eff.ne[3]);
+                (long long) V_eff.ne[0], (long long) V_eff.ne[1], (long long) V_eff.ne[2], (long long) V_eff.ne[3],
+                plan.none_reason);
             fflush(stderr);
         }
     }
@@ -2034,6 +2060,7 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
             "CUDA_FA_ROUTE_PLAN "
             "device=%d "
             "Q=[%lld,%lld,%lld,%lld] "
+            "mask=%s mask_shape=[%lld,%lld,%lld,%lld] mask_nb=[%lld,%lld,%lld,%lld] "
             "Kraw=%s Vraw=%s "
             "Kshape=[%lld,%lld,%lld,%lld] Vshape=[%lld,%lld,%lld,%lld] "
             "Keff=%s Veff=%s "
@@ -2041,11 +2068,21 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
             "decode=%d dk=%d dv=%d "
             "unsafe_vec_after_turbo_v_decode=%d allow_vec=%d "
             "kernel=%s "
+            "none_reason=%s "
             "need_f16_K=%d need_f16_V=%d "
             "Knb=[%lld,%lld,%lld,%lld] Vnb=[%lld,%lld,%lld,%lld] "
             "Keff_nb=[%lld,%lld,%lld,%lld] Veff_nb=[%lld,%lld,%lld,%lld]\n",
             device,
             (long long) Q->ne[0], (long long) Q->ne[1], (long long) Q->ne[2], (long long) Q->ne[3],
+            mask ? "yes" : "no",
+            mask ? (long long) mask->ne[0] : -1LL,
+            mask ? (long long) mask->ne[1] : -1LL,
+            mask ? (long long) mask->ne[2] : -1LL,
+            mask ? (long long) mask->ne[3] : -1LL,
+            mask ? (long long) mask->nb[0] : -1LL,
+            mask ? (long long) mask->nb[1] : -1LL,
+            mask ? (long long) mask->nb[2] : -1LL,
+            mask ? (long long) mask->nb[3] : -1LL,
             ggml_type_name(K->type), ggml_type_name(V->type),
             (long long) K->ne[0], (long long) K->ne[1], (long long) K->ne[2], (long long) K->ne[3],
             (long long) V->ne[0], (long long) V->ne[1], (long long) V->ne[2], (long long) V->ne[3],
@@ -2057,6 +2094,7 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
             (int) plan.unsafe_vec_after_turbo_v_decode,
             (int) plan.allow_vec,
             ggml_cuda_fattn_kernel_name(plan.kernel),
+            plan.none_reason ? plan.none_reason : "n/a",
             (int) plan.need_generic_f16_K,
             (int) plan.need_generic_f16_V,
             (long long) K->nb[0], (long long) K->nb[1], (long long) K->nb[2], (long long) K->nb[3],
@@ -2107,6 +2145,7 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
     const ggml_tensor * Q = dst->src[0];
     const ggml_tensor * K = dst->src[1];
     const ggml_tensor * V = dst->src[2];
+    const ggml_tensor * mask = dst->src[3];
 
 #if defined(GGML_CUDA_FA_ALL_QUANTS) || defined(GGML_CUDA_FA_HALF_QUANTS)
     if ((ggml_cuda_fattn_is_ranked_kv_type(K->type) || ggml_cuda_fattn_is_ranked_kv_type(V->type)) &&
@@ -2508,8 +2547,31 @@ void ggml_cuda_flash_attn_ext(ggml_backend_cuda_context & ctx, ggml_tensor * dst
 
         switch (selected_kernel) {
             case BEST_FATTN_KERNEL_NONE:
-                fprintf(stderr, "No CUDA FA kernel selected: K=%s V=%s D=%lld\n",
-                    ggml_type_name(K->type), ggml_type_name(V->type), (long long) Q->ne[0]);
+                fprintf(stderr,
+                    "No CUDA FA kernel selected: "
+                    "Q=[%lld,%lld,%lld,%lld] "
+                    "K=%s Kshape=[%lld,%lld,%lld,%lld] Knb=[%lld,%lld,%lld,%lld] "
+                    "V=%s Vshape=[%lld,%lld,%lld,%lld] Vnb=[%lld,%lld,%lld,%lld] "
+                    "mask=%s mask_shape=[%lld,%lld,%lld,%lld] mask_nb=[%lld,%lld,%lld,%lld] "
+                    "allow_vec=%d none_reason=%s\n",
+                    (long long) Q->ne[0], (long long) Q->ne[1], (long long) Q->ne[2], (long long) Q->ne[3],
+                    ggml_type_name(K->type),
+                    (long long) K->ne[0], (long long) K->ne[1], (long long) K->ne[2], (long long) K->ne[3],
+                    (long long) K->nb[0], (long long) K->nb[1], (long long) K->nb[2], (long long) K->nb[3],
+                    ggml_type_name(V->type),
+                    (long long) V->ne[0], (long long) V->ne[1], (long long) V->ne[2], (long long) V->ne[3],
+                    (long long) V->nb[0], (long long) V->nb[1], (long long) V->nb[2], (long long) V->nb[3],
+                    mask ? "yes" : "no",
+                    mask ? (long long) mask->ne[0] : -1LL,
+                    mask ? (long long) mask->ne[1] : -1LL,
+                    mask ? (long long) mask->ne[2] : -1LL,
+                    mask ? (long long) mask->ne[3] : -1LL,
+                    mask ? (long long) mask->nb[0] : -1LL,
+                    mask ? (long long) mask->nb[1] : -1LL,
+                    mask ? (long long) mask->nb[2] : -1LL,
+                    mask ? (long long) mask->nb[3] : -1LL,
+                    (int) plan.allow_vec,
+                    plan.none_reason ? plan.none_reason : "n/a");
                 GGML_ABORT("no CUDA FA kernel selected");
             case BEST_FATTN_KERNEL_TILE:
                 ggml_cuda_flash_attn_ext_tile(ctx, dst);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -1854,6 +1854,36 @@ struct ggml_cuda_fattn_route_plan {
     best_fattn_kernel kernel;
 };
 
+static inline bool ggml_cuda_fattn_can_force_hip_tile_fallback(
+        const ggml_tensor * Q,
+        const ggml_tensor * K,
+        const ggml_tensor * V,
+        const ggml_tensor * mask,
+        const ggml_cuda_fattn_route_plan & plan) {
+#if defined(GGML_USE_HIP)
+    if (plan.effective_type_K != GGML_TYPE_F16 || plan.effective_type_V != GGML_TYPE_F16) {
+        return false;
+    }
+
+    if (Q->ne[0] != 256 || K->ne[0] != 256 || V->ne[0] != 256) {
+        return false;
+    }
+
+    if (mask && mask->ne[2] != 1) {
+        return false;
+    }
+
+    return true;
+#else
+    GGML_UNUSED(Q);
+    GGML_UNUSED(K);
+    GGML_UNUSED(V);
+    GGML_UNUSED(mask);
+    GGML_UNUSED(plan);
+    return false;
+#endif
+}
+
 static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int device, const ggml_tensor * dst) {
     GGML_ASSERT(dst != nullptr);
     GGML_ASSERT(dst->src[0] != nullptr);
@@ -1960,6 +1990,27 @@ static ggml_cuda_fattn_route_plan ggml_cuda_fattn_make_route_plan(const int devi
     plan.allow_vec = !plan.unsafe_vec_after_turbo_v_decode;
 
     plan.kernel = ggml_cuda_get_best_fattn_kernel(device, &dst_eff, plan.allow_vec);
+
+    if (plan.kernel == BEST_FATTN_KERNEL_NONE &&
+        ggml_cuda_fattn_can_force_hip_tile_fallback(Q, &K_eff, &V_eff, dst->src[3], plan)) {
+        plan.kernel = BEST_FATTN_KERNEL_TILE;
+
+        if (ggml_cuda_fattn_route_debug_enabled()) {
+            fprintf(stderr,
+                "CUDA_FA_ROUTE_FALLBACK "
+                "device=%d forcing=HIP_TILE "
+                "Q=[%lld,%lld,%lld,%lld] "
+                "Keff=%s Veff=%s "
+                "Kshape=[%lld,%lld,%lld,%lld] Vshape=[%lld,%lld,%lld,%lld]\n",
+                device,
+                (long long) Q->ne[0], (long long) Q->ne[1], (long long) Q->ne[2], (long long) Q->ne[3],
+                ggml_type_name(plan.effective_type_K),
+                ggml_type_name(plan.effective_type_V),
+                (long long) K_eff.ne[0], (long long) K_eff.ne[1], (long long) K_eff.ne[2], (long long) K_eff.ne[3],
+                (long long) V_eff.ne[0], (long long) V_eff.ne[1], (long long) V_eff.ne[2], (long long) V_eff.ne[3]);
+            fflush(stderr);
+        }
+    }
 
     plan.need_generic_f16_K = false;
     plan.need_generic_f16_V = false;


### PR DESCRIPTION
## Summary

This fixes the surviving HIP FlashAttention routing hole on the `v0.3.2` two-GPU tensor-split + `draft-mtp` serving path for Gemma 4.

The original version of this PR fixed one `D=256` route hole, but repeated-request serving was still not stable. With prompt reuse enabled, the server could still abort on later turns after slot reuse and checkpoint restore.

The updated change keeps the failing path serving-safe by widening the HIP `D=256` fallback and by logging the full FA route inputs at the abort site.

## Reproduction

Command under test:

```bash
GGML_CUDA_ALLREDUCE=nccl HIP_VISIBLE_DEVICES=0,1 build-rocm-rccl/bin/llama-server \
  -hf "unsloth/gemma-4-31b-it-GGUF:UD-Q4_K_XL" \
  --spec-type draft-mtp \
  --spec-draft-n-max 10 \
  --host 0.0.0.0 \
  --port 8080 \
  -fa on \
  --reasoning on \
  --reasoning-loop-min-tokens 16384 \
  -ngl 999 \
  -fit off \
  --temp 1.0 --top-p 0.95 --top-k 64 \
  --ctx-size 32768 \
  -np 1 \
  --threads 8 \
  --mmap \
  --no-mmproj \
  --cache-ram 0 \
  -sm tensor \
  -ts 1,1 \
  -ctk f16 \
  -ctv f16 \
  -b 2048 -ub 512 \
  --metrics \
  --log-timestamps
```

RCCL is active in the tested build:

- `librccl.so.1` is linked into `libggml-hip.so`
- `GGML_CUDA_NCCL:BOOL=ON`
- `GGML_HIP_RCCL:BOOL=ON`

Observed failing pattern before the update:

- first request succeeds
- second request may succeed
- later request after web-UI style chat reuse can abort with:

```text
No CUDA FA kernel selected: K=f16 V=f16 D=256
```

The important part is not browser UI specifically, but the request shape it drives:

- same slot reused by high LCP similarity
- restored context checkpoint
- MTP draft decode over reused conversation state

## Root Cause

The crash is in the MTP draft decode path:

- `common_speculative_impl_draft_mtp::draft`
- `llama_decode`
- `ggml_cuda_flash_attn_ext`

This was not an RCCL failure and not a generic tensor-split failure. It was a HIP FlashAttention route-selection hole that only shows up on reused-context draft graphs.

For the failing path, the effective FA inputs are still a legal `f16/f16 D=256` attention shape, but the planner could still return `BEST_FATTN_KERNEL_NONE` after prompt reuse / checkpoint restore. That fed the unconditional abort in `ggml_cuda_flash_attn_ext()`.

## Change

1. Broaden the HIP tile fallback in `ggml_cuda_fattn_make_route_plan()`.

Previously the fallback was too narrow. It now covers HIP `f16/f16 D=256` reused-context shapes as long as the K sequence length is stride-compatible, instead of rejecting them because of an over-strict mask gate.

2. Add targeted route diagnostics.

When route debug is enabled, the planner now logs:

- Q/K/V shapes
- mask shape and strides
- raw and effective K/V types
- selected kernel
- `none_reason` when selection falls through

If the selector ever still reaches `BEST_FATTN_KERNEL_NONE`, the abort log now prints the full failing node shape instead of only `K`, `V`, and `D`.

## Validation

Built the HIP backend with:

```bash
cmake --build build-rocm-rccl --config RelWithDebInfo --target ggml-hip -j 8
```

Validated with a persistent single-slot chat conversation against the same server config, including:

- LCP-based slot reuse
- restored context checkpoints
- repeated short turns after a long code-generation turn
- repeated long + short mixed turns in one server process

Observed post-fix behavior on the test host:

- restored checkpoint at `pos_min = 271, pos_max = 1806, size = 800.013 MiB`
- repeated high-LCP reuse (`sim_best` up to `0.995`)
- no FA abort through 8 sequential same-thread requests
- graphs reused continued increasing (`324 -> 1001` in the captured run)

Representative timings from the reused-context run:

- initial long prompt: `175.87 tok/s` prompt, `77.91 tok/s` eval, acceptance `0.56006`
- later reused short turns: prompt around `81-85 tok/s`, eval around `40-46 tok/s`
- later reused long turn: `517.23 tok/s` prompt, `41.90 tok/s` eval after restored checkpoint

## Scope

This PR changes only `ggml/src/ggml-cuda/fattn.cu`.

It does not change:

- tensor split policy
- MTP scheduling
- RCCL setup
- server checkpoint logic
- sampler placement logic

There is a separate local sampler fallback fix outside this PR; it is intentionally not included here.

## Impact

This makes the HIP two-GPU tensor-split + `draft-mtp` serving path more robust under real repeated-request chat reuse by using a safe tile fallback for the remaining `f16/f16 D=256` route hole and by making any future selector failure self-describing.