### PR TITLE
Fix HIP compilation error in flash_attn_ext_vec launch bounds

### DIFF
--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -28,7 +28,7 @@ static constexpr __host__ __device__ int ggml_cuda_fattn_vec_get_min_blocks() {
 #pragma clang diagnostic ignored "-Wpass-failed"
 #endif // __clang__
 template<int D, int ncols, ggml_type type_K, ggml_type type_V, bool use_logit_softcap> // D == head size
-__launch_bounds__(ggml_cuda_fattn_vec_get_nthreads_device(), ggml_cuda_fattn_vec_get_min_blocks<type_K, type_V>())
+__launch_bounds__(ggml_cuda_fattn_vec_get_nthreads_device(), (ggml_cuda_fattn_vec_get_min_blocks<type_K, type_V>()))
 static __global__ void flash_attn_ext_vec(
         const char * Q_ptr,
         const char * K_ptr,


### PR DESCRIPTION
## Overview

Fixes a preprocessor compilation error when building for AMD GPUs via ROCm/HIP.

On HIP/ROCm, `__launch_bounds__` is defined as a preprocessor macro (expanding to `__attribute__((launch_bounds(...)))`) rather than a native compiler attribute recognized directly by the parser. Because of this, the preprocessor performs simple comma-based argument splitting. The comma inside the template parameter brackets `<type_K, type_V>` of the second parameter:
```cpp
__launch_bounds__(ggml_cuda_fattn_vec_get_nthreads_device(), ggml_cuda_fattn_vec_get_min_blocks<type_K, type_V>())
```
is mistakenly interpreted by the preprocessor as a macro argument separator, resulting in a preprocessor argument mismatch and build failure.

Wrapping the templated function call in parentheses:
```cpp
__launch_bounds__(ggml_cuda_fattn_vec_get_nthreads_device(), (ggml_cuda_fattn_vec_get_min_blocks<type_K, type_V>()))
```
forces the preprocessor to treat the whole parenthesized group as a single expression, avoiding the macro split. This resolves the build error cleanly under HIP/ROCm while maintaining full compatibility with CUDA/nvcc.

## Additional information

This issue affects all HIP/ROCm builds on unified CUDA/HIP code paths introduced recently in `v0.3.2`.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES - Antigravity was used to assist in identifying the preprocessor macro expansion issue and generating the patch format. The code changes themselves are standard syntax correction, and the final build and execution was manually verified and tested on actual hardware (Radeon 8060S running ROCm 7.14 nightlies).