### PR TITLE
cuda: silence KVarN MMA compilation warnings

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-kvarn-case.cuh
@@ -421,8 +421,10 @@ static bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(
     }
 
 #if !defined(GGML_USE_MUSA)
+    // The partial kernel does not share the FlashAttention signature, so it is
+    // passed as an opaque entry pointer instead of being cast to fattn_kernel_t.
     CUDA_CHECK(cudaFuncSetAttribute(
-        reinterpret_cast<ggml_cuda_fattn_kernel_attr_ptr_t>(
+        reinterpret_cast<const void *>(
             ggml_cuda_fattn_kvarn_window_f16_partial_kernel<DKQ, DV, ncols1, ncols2, use_logit_softcap>),
         cudaFuncAttributeMaxDynamicSharedMemorySize, nbytes_shared_total));
 #endif
@@ -837,4 +839,4 @@ void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cuda_context & ctx, gg
 
 #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \
     template void ggml_cuda_flash_attn_ext_mma_kvarn_case                          \
-    <DKQ, DV, ncols1, ncols2>(ggml_backend_cuda_context & ctx, ggml_tensor * dst)  \
+    <DKQ, DV, ncols1, ncols2>(ggml_backend_cuda_context & ctx, ggml_tensor * dst)


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Clean up many pages worth of warnings on GCC 15

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Stop GCC 15 from spitting out these pages of warnings, over and over again for each kvarn module being compiled
(the below excerpt is from compiling a single file):

```
 [914/965] Building CUDA object ggml/src/ggml-cuda/CMakeFiles/ggml-cuda.dir/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu.o               
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 In file included from ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:3:                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:838:84: warning: backslash-newline at end of file                                      
   838 | #define DECL_FATTN_MMA_KVARN_CASE(DKQ, DV, ncols1, ncols2)                         \                                                                
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = true; size_t = long unsigned int]':                                                                                                        
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:642:94:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   642 |             return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, true>(                                            
       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~                                            
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:5:123:   required from here                                          
     5 | DECL_FATTN_MMA_KVARN_CASE(128, 128, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^                                                                                                             
                                                                                                                                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = false; size_t = long unsigned int]':                                                                                                       
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:645:95:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   645 |         return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, false>(                                               
       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~                                               
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 128; int DV = 128; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:5:123:   required from here                                          
     5 | DECL_FATTN_MMA_KVARN_CASE(128, 128, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^                                                                                                             
                                                                                                                                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = true; size_t = long unsigned int]':                                                                                                        
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:642:94:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   642 |             return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, true>(                                            
       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~                                            
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:6:123:   required from here                                          
     6 | DECL_FATTN_MMA_KVARN_CASE(256, 256, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^                                                                                                             
                                                                                                                                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = false; size_t = long unsigned int]':                                                                                                       
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:645:95:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   645 |         return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, false>(                                               
       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~                                               
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 256; int DV = 256; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:6:123:   required from here                                          
     6 | DECL_FATTN_MMA_KVARN_CASE(256, 256, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^                                                                                                             
                                                                                                                                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = true; size_t = long unsigned int]':                                                                                                        
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:642:94:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   642 |             return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, true>(                                            
       |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~                                            
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:7:123:   required from here                                          
     7 | DECL_FATTN_MMA_KVARN_CASE(512, 512, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^                                                                                                             
                                                                                                                                                             
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh: In instantiation of 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl(ggml_ 
 backend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4; bool use 
 _logit_softcap = false; size_t = long unsigned int]':                                                                                                       
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:645:95:   required from 'bool ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case(ggml_ba 
 ckend_cuda_context&, ggml_tensor*, const ggml_cuda_fattn_kvarn_plan&, size_t, bool) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4; size 
 _t = long unsigned int]'                                                                                                                                    
   645 |         return ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case_impl<DKQ, DV, ncols1, ncols2, false>(                                               
       |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~                                               
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:821:80:   required from 'void ggml_cuda_flash_attn_ext_mma_kvarn_case(ggml_backend_cud 
 a_context&, ggml_tensor*) [with int DKQ = 512; int DV = 512; int ncols1 = 2; int ncols2 = 4]'                                                               
   821 |     if (ggml_cuda_flash_attn_ext_mma_kvarn_windowed_case<DKQ, DV, ncols1, ncols2>(                                                                  
       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~                                                                  
 ../ggml/src/ggml-cuda/template-instances/fattn-mma-kvarn-instance-ncols1_2-ncols2_4.cu:7:123:   required from here                                          
     7 | DECL_FATTN_MMA_KVARN_CASE(512, 512, 2, 4);                                                                                                          
       |                                                                                                                           ^                         
 ../ggml/src/ggml-cuda/template-instances/../fattn-mma-kvarn-case.cuh:424:39: warning: cast between incompatible function types from 'void (*)(const char*,  
 const char*, const char*, const char*, const char*, float2*, float, float, float, float, uint32_t, float, int32_t, uint3, int32_t, int32_t, int32_t, int32_ 
 t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t, int32_t, int32_t, int64_t)' {aka 'void (*)(const char 
 *, const char*, const char*, const char*, const char*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int, int, int, int,  
 int, int, int, int, int, long int, int, int, long int, int, int, long int)'} to 'ggml_cuda_fattn_kernel_attr_ptr_t' {aka 'void (*)(const char*, const char* 
 , const char*, const char*, const char*, const int*, float*, float2*, float2*, float, float, float, float, unsigned int, float, int, uint3, int, int, int,  
 int, int, int, int, int, int, int, int, long int, int, int, long int, int, int, int, int, int, long int)'} [-Wcast-function-type]                           
   424 |     CUDA_CHECK(cudaFuncSetAttribute(                                                                                                                
       |                                       ^
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES, AI generated and human reviewed

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
