### PR TITLE
Fix crashes and cascading request failures under concurrent KVarN decoding

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2522,7 +2522,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
     }
 
     // wait for the computation to finish (automatically done when obtaining the model output)
-    //synchronize();
+    synchronize();
 
     return 0;
 }

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1616,6 +1616,14 @@ void llama_kv_cache::seq_cp(llama_seq_id seq_id_src, llama_seq_id seq_id_dst, ll
         auto & cells = v_cells[s0];
 
         if (seq_id_src == seq_id_dst) {
+            // Do not leave the tail copy deferred: under concurrent multi-slot
+            // decoding, a pending seq_cp transaction can be observed by another
+            // slot's clone_logical_state_from() (via restorable-prefix reuse or
+            // idle-slot RAM caching) before this call's normal deferred-commit
+            // point (the next seq_cp()) is ever reached, causing spurious
+            // "cannot clone KV cache logical state during a transaction" /
+            // pos_min == -1 failures. Commit immediately instead.
+            materialize_pending_copies();
             return;
         }
 
@@ -1646,6 +1654,10 @@ void llama_kv_cache::seq_cp(llama_seq_id seq_id_src, llama_seq_id seq_id_dst, ll
         }
 
         rebuild_allocation_head(seq_id_dst);
+
+        // See the seq_id_src == seq_id_dst branch above: commit the tail copy
+        // immediately rather than leaving it deferred until the next seq_cp().
+        materialize_pending_copies();
 
         return;
     }
@@ -1988,35 +2000,53 @@ llama_kv_cache::slot_info_vec_t llama_kv_cache::prepare(const std::vector<llama_
 
     bool success = true;
 
-    tail_preparing = true;
-    for (const auto & ubatch : ubatches) {
-        // only find a suitable slot for the ubatch. don't modify the cells yet
-        const auto sinfo_new = find_slot(ubatch, false);
-        if (sinfo_new.empty()) {
-            success = false;
-            break;
-        }
+    {
+        // find_slot()/apply_ubatch() below can throw (e.g. "structured KV live
+        // groups alias one F16 stage slot"). Without an RAII guard, such an
+        // exception unwinds out of this function and leaves tail_preparing
+        // stuck at true forever, since the plain assignment that used to reset
+        // it is skipped. Every subsequent clone_logical_state_from() call
+        // (restorable-prefix reuse, idle-slot RAM restore) then observes
+        // tail_preparing == true and spuriously fails with "cannot clone KV
+        // cache logical state during a transaction" until some later prepare()
+        // call happens to complete without throwing. Use the same RAII guard
+        // pattern already used elsewhere in this file (see the other
+        // tail_preparing_guard uses) so the flag is always restored.
+        struct tail_preparing_guard {
+            bool & value;
+            bool old;
+            ~tail_preparing_guard() { value = old; }
+        } guard { tail_preparing, tail_preparing };
+        tail_preparing = true;
 
-        // remember the position that we found
-        res.push_back(sinfo_new);
-
-        // store the old state of the cells in the recovery stack
-        {
-            state_t state = { sinfo_new, v_heads, {} };
-
-            for (uint32_t s = 0; s < sinfo_new.n_stream(); ++s) {
-                auto & cells = v_cells[sinfo_new.strm[s]];
-
-                state.v_cells.push_back(cells.cp(sinfo_new.idxs[s]));
+        for (const auto & ubatch : ubatches) {
+            // only find a suitable slot for the ubatch. don't modify the cells yet
+            const auto sinfo_new = find_slot(ubatch, false);
+            if (sinfo_new.empty()) {
+                success = false;
+                break;
             }
 
-            states.push_back(std::move(state));
-        }
+            // remember the position that we found
+            res.push_back(sinfo_new);
 
-        // now emplace the ubatch
-        apply_ubatch(sinfo_new, ubatch);
+            // store the old state of the cells in the recovery stack
+            {
+                state_t state = { sinfo_new, v_heads, {} };
+
+                for (uint32_t s = 0; s < sinfo_new.n_stream(); ++s) {
+                    auto & cells = v_cells[sinfo_new.strm[s]];
+
+                    state.v_cells.push_back(cells.cp(sinfo_new.idxs[s]));
+                }
+
+                states.push_back(std::move(state));
+            }
+
+            // now emplace the ubatch
+            apply_ubatch(sinfo_new, ubatch);
+        }
     }
-    tail_preparing = false;
 
     GGML_ASSERT(!states.empty() || !success);
 
@@ -2377,7 +2407,20 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
             if (group > 0) {
                 const uint32_t slot = stage_slot(group);
                 if (stage_owners[slot] >= 0 && uint32_t(stage_owners[slot]) != group) {
-                    throw std::runtime_error("structured KV live groups alias one F16 stage slot");
+                    // Two live sequences currently want the same F16 stage
+                    // slot for their in-progress (incomplete) record group.
+                    // This is a resource-contention condition, not a data
+                    // invariant violation: nothing has been written yet (this
+                    // is a pure planning pass, see the caller's separate
+                    // apply_ubatch() step). Report "no slot found" the same
+                    // way as ordinary out-of-space below, instead of throwing.
+                    // Previously this threw std::runtime_error, which
+                    // propagates out of llama_decode() and is caught by the
+                    // server as "decode() failed", triggering
+                    // abort_all_slots() -- failing every other concurrently
+                    // in-flight request (not just this one) for what is
+                    // normally just a "try again next tick" condition.
+                    return {};
                 }
                 stage_owners[slot] = int32_t(group);
             }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -27,6 +27,8 @@
 #include <filesystem>
 #include <utility>
 #include <fstream>
+#include <thread>
+#include <chrono>
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
@@ -3737,10 +3739,35 @@ private:
                             const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
-                                const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
+                                auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
                                 if (pos_min == -1) {
-                                    SLT_ERR(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d\n", n_past, (int) slot.prompt.tokens.size(), slot.id, pos_min);
-                                    GGML_ABORT("pos_min == -1, but n_past > 0 - should not happen: https://github.com/ggml-org/llama.cpp/pull/13833#discussion_r2116181237");
+                                    // Recovery instead of GGML_ABORT: under concurrent KVarN/checkpoint
+                                    // transaction contention, this slot's sequence can be left with zero
+                                    // KV cells by a racing operation on another slot even though our own
+                                    // bookkeeping still thinks n_past > 0. Rather than crash the whole
+                                    // server, degrade this slot to a clean state and force full
+                                    // reprocessing of its prompt, same as the missing-cache-data path.
+                                    SLT_ERR(slot, "n_past = %d, slot.prompt.tokens.size() = %d, seq_id = %d, pos_min = %d (recovering via full reprocess instead of aborting)\n", n_past, (int) slot.prompt.tokens.size(), slot.id, pos_min);
+                                    // Do NOT go through slot.mem.seq_rm()/common_memory::seq_rm(): that
+                                    // wrapper GGML_ABORTs the whole process if llama_memory_seq_rm()
+                                    // returns false, which is exactly what happens when the attention or
+                                    // recurrent sub-cache reports a pending transaction (the same
+                                    // condition that produced pos_min == -1 here). Call the raw C API
+                                    // directly so a transient refusal is just a bool we can retry on.
+                                    bool cleared = llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+                                    for (int attempt = 0; !cleared && attempt < 50; ++attempt) {
+                                        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                                        cleared = llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+                                    }
+                                    if (!cleared) {
+                                        SLT_ERR(slot, "pos_min recovery: seq_rm still refused after retries; sequence state may remain inconsistent (seq_id = %d)\n", slot.id);
+                                    }
+                                    n_past = 0;
+                                    slot.n_prompt_tokens_lcp = 0;
+                                    slot.prompt_cache_source = "none";
+                                    slot.prompt_cache_reason = "pos_min_recovery";
+                                    pos_next = slot.prompt.tokens.pos_next(n_past);
+                                    pos_min = 0;
                                 }
 
                                 // when the prompt prefix does not match, print the tokens around the mismatch
@@ -4189,14 +4216,53 @@ private:
         metrics.on_decoded(slots);
 
         if (ret != 0) {
+            if (n_batch == 1 && ret == 1) {
+                // n_batch has already been reduced to a single token and even
+                // that token could not find a memory slot (llama_decode()
+                // returns 1 from llama_kv_cache::prepare()'s find_slot()
+                // rejecting it during planning -- nothing has been computed
+                // for this token yet, unlike ret == -1 / ret < -1 below,
+                // which are genuine invalid-input/compute failures with
+                // uncertain partial state and must stay conservative).
+                //
+                // batch_view contains exactly this one token, so unlike the
+                // general case we know precisely which slot(s) it belongs to
+                // and can release just those, instead of aborting every
+                // other currently-processing slot that has nothing to do
+                // with this token. Previously this always fell into the
+                // "abort every processing slot" logic below, so a single
+                // slot's resource contention (e.g. transient KVarN F16 stage
+                // pool contention under -kvu) would fail every other
+                // concurrently in-flight request too.
+                const std::string err = "Context size has been exceeded.";
+
+                GGML_ASSERT(batch_view.n_tokens == 1);
+                for (int32_t j = 0; j < batch_view.n_seq_id[0]; ++j) {
+                    const llama_seq_id seq_id = batch_view.seq_id[0][j];
+
+                    for (auto & slot : slots) {
+                        if (slot.is_processing() && slot.id == seq_id) {
+                            SRV_ERR("%s off = %d, n_batch = %d, ret = %d, slot = %d\n",
+                                    err.c_str(), off, n_batch, ret, slot.id);
+
+                            send_error(slot, err);
+                            slot.release();
+
+                            // note: it's complicated to keep track of how much of the current batch has been
+                            //       processed before the error occurred, so we simply clear the entire context
+                            slot.prompt_clear();
+                        }
+                    }
+                }
+
+                // this token's own slot has been released; treat as handled
+                // so the caller advances past it and the remaining, unrelated
+                // slots continue processing normally.
+                return true;
+            }
+
             {
                 std::string err;
-
-                if (n_batch == 1 && ret == 1) {
-                    // TODO: try to terminate only the largest active slot/sequence and continue with the rest
-                    //       need to remove the tokens from the current batch too
-                    err = "Context size has been exceeded.";
-                }
 
                 if (ret == -1) {
                     err = "Invalid input batch.";


### PR DESCRIPTION
## Summary

Under `-np 12 -kvu` (unified KVarN cache, many concurrent slots), sustained concurrent load reliably crashed the server process and/or failed a large fraction of concurrent requests. This PR fixes four related bugs found while investigating that:

1. **`llama-context.cpp`**: `decode()` ends with a commented-out `synchronize()` call. Without it, an async tensor copy can race with the next operation, contributing to the `pos_min == -1` assert crash below. Same missing call as ggml-org/llama.cpp#18310.
2. **`server-context.cpp` (`pos_min == -1` `GGML_ABORT`)**: under KVarN's tail checkpoint/transaction machinery, a slot's sequence can transiently report zero KV cells due to a race with another slot's in-flight transaction. Recover (full reprocess) instead of aborting the whole process. The recovery path avoids `slot.mem.seq_rm()` (which itself `GGML_ABORT`s on the same condition) by calling the raw C API directly with a short bounded retry.
3. **`llama-kv-cache.cpp` (`tail_preparing` stuck `true`)**: `prepare()` used a plain assignment instead of the RAII guard already used elsewhere in the file for the same flag. Since `find_slot()` can throw, an exception left `tail_preparing` stuck at `true`, causing every later `clone_logical_state_from()` call to spuriously fail with "cannot clone KV cache logical state during a transaction".
4. **Cascading abort on F16 stage-pool contention**: `find_slot()`'s structured allocation path threw when two live sequences' incomplete record groups hashed to the same F16 stage slot. This is ordinary resource contention (nothing written yet, pure planning pass), but throwing propagates out of `llama_decode()` and gets caught by the server as "decode() failed", which aborted *every* processing slot, not just the one that hit the contention. Now reports "no slot found" the same way as ordinary out-of-space. Symmetrically, `server-context.cpp`'s own batch-splitting retry loop had the same issue at `n_batch == 1`: it aborted every processing slot even though `batch_view` at that point contains exactly one token whose owning slot is known precisely, so only that slot is released now (this matches a TODO already left in that code by the original author).

Also (`llama-kv-cache.cpp` `seq_cp`): commit pending tail copies immediately in the same-stream case instead of leaving them deferred until the next `seq_cp()` call, since a pending transaction can otherwise be observed by another slot's `clone_logical_state_from()` first.

## Test plan

- 225-request sweep at `-np 12 -kvu --kv-tail-tokens 256`, 12-way concurrency, `max_tokens=6000`: server process crashes went from frequent (multiple per run, sometimes within ~500-600 requests) to **zero across every run** after these fixes.
- Confirmed via server PID staying constant across full sweeps, both before/after comparisons on the same hardware/model (Qwen3.5-based hybrid architecture, KVarN 2-bit cache).

## Known remaining issue (not fixed here)

Individual request failure rate (HTTP 500, not crashes) is still elevated under sustained 12-way concurrency, because `find_slot()`'s `group -> stage slot` assignment is a stateless `group % allocation_stage_groups` hash over an unbounded group index, so collisions (now handled gracefully instead of crashing) still occur reasonably often. A real fix needs either a collision-free persistent per-sequence slot assignment, which would also require updating every `stage_slot` computation in `ggml-cuda/kvarn.cu` to match (multiple kernels independently recompute the same modulo formula), or raising `allocation_stage_groups`, which trades VRAM for a lower collision rate. Happy to discuss approaches for a follow-up.