### PR TITLE
--prefetch-experts-slots: lookahead H2D prefetch of host-resident MoE expert weights

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2036,6 +2036,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
                            }
                        }).set_env("LLAMA_ARG_FLASH_ATTN"));
     add_opt(common_arg(
+        {"--prefetch-experts-slots"}, "N",
+        "MoE expert H2D staging slots (default 0 = off; N>=2 enables full-tensor prefetch with 1-deep lookahead for host-resident/ncmoe-offloaded expert weights during prefill; recommended 3; capped at 4). GPU memory cost = N x max_expert_tensor.",
+        [](common_params & params, const std::string & value) {
+            params.prefetch_experts_slots = std::stoi(value);
+        }
+    ));
+    add_opt(common_arg(
         {"-p", "--prompt"}, "PROMPT",
         "prompt to start generation with; for system message, use -sys",
         [](common_params & params, const std::string & value) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1925,6 +1925,7 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.offload_kqv       = !params.no_kv_offload;
     cparams.no_perf           = params.no_perf;
     cparams.op_offload        = !params.no_op_offload;
+    cparams.prefetch_experts_slots = params.prefetch_experts_slots;
     cparams.swa_full          = params.swa_full;
     cparams.kv_unified        = params.kv_unified;
 

--- a/common/common.h
+++ b/common/common.h
@@ -561,6 +561,7 @@ struct common_params {
     enum llama_pooling_type      pooling_type      = LLAMA_POOLING_TYPE_UNSPECIFIED; // pooling type for embeddings
     enum llama_attention_type    attention_type    = LLAMA_ATTENTION_TYPE_UNSPECIFIED; // attention type for embeddings
     enum llama_flash_attn_type   flash_attn_type   = LLAMA_FLASH_ATTN_TYPE_AUTO; // whether to use Flash Attention
+    int prefetch_experts_slots = 0; // --prefetch-experts-slots: MoE expert H2D staging slots (0 = off, >=2 enables full-tensor lookahead prefetch of ncmoe-offloaded weights; recommended 3; capped at 4)
 
     struct common_params_sampling    sampling;
     struct common_params_speculative speculative;

--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -393,6 +393,15 @@ extern "C" {
     // Set a callback to be called for each resulting node during graph compute
     GGML_API void                 ggml_backend_sched_set_eval_callback(ggml_backend_sched_t sched, ggml_backend_sched_eval_callback callback, void * user_data);
 
+    // Configure full-tensor MoE expert prefetch on a scheduler (mindcontrol port of
+    // --prefetch-experts-slots). Only engages for splits whose MUL_MAT_ID weights are
+    // host-resident (GGML_BACKEND_BUFFER_USAGE_WEIGHTS, e.g. --n-cpu-moe) during large
+    // prefill batches; decode is unaffected (batch ids < 2*n_expert).
+    //   slots == 0  -> prefetch disabled (no memory overhead)
+    //   slots >= 2  -> prefetch enabled with 1-deep lookahead and per-split cross-stream wait;
+    //                  GPU staging cost = slots * max_expert_tensor. Capped at GGML_SCHED_MAX_PREFETCH_SLOTS.
+    GGML_API void                 ggml_backend_sched_set_prefetch_experts_slots(ggml_backend_sched_t sched, int slots);
+
     //
     // Meta backend
     //

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -789,6 +789,10 @@ static bool ggml_backend_sched_allows_bufferless_kvarn_src(
 #define GGML_SCHED_MAX_COPIES 4
 #endif
 
+#ifndef GGML_SCHED_MAX_PREFETCH_SLOTS
+#define GGML_SCHED_MAX_PREFETCH_SLOTS 4
+#endif
+
 struct ggml_backend_sched_split {
     int backend_id;
     int i_start;
@@ -842,6 +846,24 @@ struct ggml_backend_sched {
 
     ggml_backend_sched_eval_callback callback_eval;
     void * callback_eval_user_data;
+
+    // mindcontrol-port of --prefetch-experts-slots: full-tensor lookahead prefetch of
+    // offloaded MUL_MAT_ID weights (MoE experts resident in CPU/host memory, i.e. ncmoe).
+    // While split[i] computes, a second backend instance on the same device uploads
+    // split[i+1+LOOKAHEAD]'s weight tensor into rotating staging slots; the consuming
+    // split waits on the slot's ready event right before launch (per-split wait mode 1,
+    // the only mode that preserves tool_choice semantics). Staging cost = n_slots x
+    // max_expert_tensor; lazy-allocated at first fire, gracefully disabled on any failure.
+    bool prefetch_experts;
+    ggml_backend_t prefetch_backend;   // second backend instance on the same device
+    int prefetch_n_slots;
+    int prefetch_lookahead;            // 1 = fire split i+2 while split i computes (measured-optimal)
+    int prefetch_wait_mode;            // 1 = per-split cross-stream wait; >=2 = one wait per graph (debug)
+    ggml_backend_buffer_t prefetch_slots[GGML_SCHED_MAX_PREFETCH_SLOTS];
+    ggml_backend_event_t  prefetch_ready[GGML_SCHED_MAX_PREFETCH_SLOTS];
+    ggml_backend_event_t  prefetch_free [GGML_SCHED_MAX_PREFETCH_SLOTS];
+    bool prefetch_used[GGML_SCHED_MAX_PREFETCH_SLOTS];
+    int prefetch_cur;
 
     char * context_buffer;
     size_t context_buffer_size;
@@ -1736,6 +1758,91 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
     return true;
 }
 
+// ---- mindcontrol-port prefetch helpers (--prefetch-experts-slots) ----
+static void ggml_backend_sched_prefetch_disable(ggml_backend_sched_t sched, ggml_backend_t split_backend) {
+    sched->prefetch_experts = false;
+    if (sched->prefetch_backend) {
+        ggml_backend_synchronize(split_backend);
+        ggml_backend_synchronize(sched->prefetch_backend);
+    }
+    for (int i = 0; i < sched->prefetch_n_slots; i++) {
+        ggml_backend_buffer_free(sched->prefetch_slots[i]);
+        sched->prefetch_slots[i] = NULL;
+        sched->prefetch_used[i] = false;
+    }
+}
+
+static size_t ggml_backend_sched_prefetch_max_size(ggml_backend_sched_t sched) {
+    size_t max_size = 0;
+    for (int split_id = 0; split_id < sched->n_splits; split_id++) {
+        struct ggml_backend_sched_split * split = &sched->splits[split_id];
+        if (split->graph.n_nodes == 0 || split->graph.nodes[0]->op != GGML_OP_MUL_MAT_ID) {
+            continue;
+        }
+        for (int input_id = 0; input_id < split->n_inputs; input_id++) {
+            const ggml_tensor * input = split->inputs[input_id];
+            if (input->buffer &&
+                ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                ggml_backend_buffer_is_host(input->buffer)) {
+                max_size = std::max(max_size, ggml_nbytes(input));
+            }
+        }
+    }
+    return max_size;
+}
+
+static bool ggml_backend_sched_prefetch_init(ggml_backend_sched_t sched, ggml_backend_t split_backend, size_t size) {
+    if (sched->prefetch_backend == NULL) {
+        ggml_backend_dev_t dev = split_backend->device;
+        ggml_backend_dev_props props;
+        ggml_backend_dev_get_props(dev, &props);
+        if (!props.caps.async || !props.caps.events) {
+            sched->prefetch_experts = false;
+            return false;
+        }
+        sched->prefetch_backend = ggml_backend_dev_init(dev, NULL);
+        if (sched->prefetch_backend == NULL) {
+            sched->prefetch_experts = false;
+            return false;
+        }
+        for (int i = 0; i < sched->prefetch_n_slots; i++) {
+            sched->prefetch_ready[i] = ggml_backend_event_new(dev);
+            sched->prefetch_free[i]  = ggml_backend_event_new(dev);
+            if (sched->prefetch_ready[i] == NULL || sched->prefetch_free[i] == NULL) {
+                sched->prefetch_experts = false;
+                return false;
+            }
+        }
+    }
+
+    size = std::max(size, ggml_backend_sched_prefetch_max_size(sched));
+
+    ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(split_backend);
+    for (int i = 0; i < sched->prefetch_n_slots; i++) {
+        if (sched->prefetch_slots[i] == NULL || ggml_backend_buffer_get_size(sched->prefetch_slots[i]) < size) {
+            ggml_backend_buffer_t new_buf = ggml_backend_buft_alloc_buffer(buft, size);
+            if (new_buf == NULL) {
+                if (i >= 2 && sched->prefetch_slots[0] != NULL &&
+                    ggml_backend_buffer_get_size(sched->prefetch_slots[0]) >= size) {
+                    sched->prefetch_n_slots = i;
+                    sched->prefetch_cur = 0;
+                    return true;
+                }
+                ggml_backend_sched_prefetch_disable(sched, split_backend);
+                return false;
+            }
+            if (sched->prefetch_slots[i] != NULL) {
+                ggml_backend_synchronize(split_backend);
+                ggml_backend_synchronize(sched->prefetch_backend);
+                ggml_backend_buffer_free(sched->prefetch_slots[i]);
+            }
+            sched->prefetch_slots[i] = new_buf;
+            sched->prefetch_used[i] = false;
+        }
+    }
+    return true;
+}
+
 static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t sched) {
     GGML_ASSERT(sched);
     struct ggml_backend_sched_split * splits = sched->splits;
@@ -1746,10 +1853,98 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
 
     int prev_backend_id = -1;
 
+    // mindcontrol-port of --prefetch-experts-slots. Lookahead depth (1) and cross-stream
+    // wait mode (1 = per-split, the only mode that preserves tool_choice semantics) are
+    // hardcoded to their measured-optimal safe values; the only user-visible knob is the
+    // slot count, set via ggml_backend_sched_set_prefetch_experts_slots(). LOOKAHEAD must
+    // stay < prefetch_n_slots. Modes 0 and 2 are internal-only debug values.
+    const int LOOKAHEAD = sched->prefetch_lookahead;
+    const int prefetch_wait_mode = sched->prefetch_wait_mode;
+    std::vector<int> pending_prefetch_slots;
+    ggml_backend_t last_prefetch_split_backend = NULL;
+
+    // Fire H2D for split[i+1+LOOKAHEAD] while split[i] computes, so by the consuming
+    // split's per-split wait the upload is already done and the wait is a no-op.
+    struct prefetch_pending {
+        int slot = -1;
+        ggml_tensor * input_cpy = NULL;
+        ggml_backend_buffer_t saved_buffer = NULL;
+        void * saved_data = NULL;
+    };
+    std::vector<prefetch_pending> lookahead(sched->n_splits);
+
+    auto try_fire_prefetch = [&](int target_id) {
+        if (target_id >= sched->n_splits) return;
+        if (!sched->prefetch_experts || sched->callback_eval) return;
+        if (lookahead[target_id].slot != -1) return;
+        struct ggml_backend_sched_split * s = &splits[target_id];
+        if (s->graph.n_nodes == 0 || s->n_inputs == 0) return;
+        ggml_tensor * node = s->graph.nodes[0];
+        if (node->op != GGML_OP_MUL_MAT_ID) return;
+
+        ggml_tensor * input = NULL;
+        ggml_tensor * input_cpy = NULL;
+        for (int i = 0; i < s->n_inputs; i++) {
+            ggml_tensor * cand = s->inputs[i];
+            if (cand->flags & GGML_TENSOR_FLAG_INPUT) continue;
+            ggml_tensor * cand_cpy = tensor_copy(cand, s->backend_id, sched->cur_copy);
+            if (node->src[0] == cand_cpy) { input = cand; input_cpy = cand_cpy; break; }
+        }
+        if (!input) return;
+        if (ggml_backend_buffer_get_usage(input->buffer) != GGML_BACKEND_BUFFER_USAGE_WEIGHTS) return;
+        const ggml_tensor * ids = node->src[2];
+        const int64_t n_expert = input->ne[2];
+        if (ids->ne[0]*ids->ne[1] < 2*n_expert) return;
+
+        ggml_backend_t s_backend = sched->backends[s->backend_id];
+        if (!ggml_backend_sched_prefetch_init(sched, s_backend, ggml_nbytes(input))) return;
+
+        const int slot = sched->prefetch_cur;
+        sched->prefetch_cur = (sched->prefetch_cur + 1) % sched->prefetch_n_slots;
+        if (sched->prefetch_used[slot]) {
+            ggml_backend_event_wait(sched->prefetch_backend, sched->prefetch_free[slot]);
+        }
+        lookahead[target_id].slot = slot;
+        lookahead[target_id].input_cpy = input_cpy;
+        lookahead[target_id].saved_buffer = input_cpy->buffer;
+        lookahead[target_id].saved_data = input_cpy->data;
+        input_cpy->buffer = sched->prefetch_slots[slot];
+        input_cpy->data = ggml_backend_buffer_get_base(sched->prefetch_slots[slot]);
+        ggml_backend_tensor_set_async(sched->prefetch_backend, input_cpy, input->data, 0, ggml_nbytes(input));
+        ggml_backend_event_record(sched->prefetch_ready[slot], sched->prefetch_backend);
+    };
+
+    // Prime the pipeline: fire prefetch for splits [0, LOOKAHEAD]
+    if (LOOKAHEAD > 0) {
+        for (int i = 0; i <= LOOKAHEAD && i < sched->n_splits; i++) {
+            try_fire_prefetch(i);
+        }
+    }
+
     for (int split_id = 0; split_id < sched->n_splits; split_id++) {
         struct ggml_backend_sched_split * split = &splits[split_id];
         int split_backend_id = split->backend_id;
         ggml_backend_t split_backend = sched->backends[split_backend_id];
+
+        // mindcontrol-port: per-split prefetch state, consumed when this split was the
+        // target of a lookahead fire
+        int split_prefetch_slot = -1;
+        ggml_tensor * prefetch_input_cpy = NULL;
+        ggml_backend_buffer_t prefetch_saved_buffer = NULL;
+        void * prefetch_saved_data = NULL;
+        int lookahead_input_id = -1;
+        if (lookahead[split_id].slot != -1) {
+            split_prefetch_slot   = lookahead[split_id].slot;
+            prefetch_input_cpy    = lookahead[split_id].input_cpy;
+            prefetch_saved_buffer = lookahead[split_id].saved_buffer;
+            prefetch_saved_data   = lookahead[split_id].saved_data;
+            for (int i = 0; i < split->n_inputs; i++) {
+                if (tensor_copy(split->inputs[i], split_backend_id, sched->cur_copy) == prefetch_input_cpy) {
+                    lookahead_input_id = i;
+                    break;
+                }
+            }
+        }
 
         // ensure the previous split's async work has completed before we start
         // this split, the allocator may have reused buffer regions across splits
@@ -1763,6 +1958,7 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
 
         // copy the input tensors to the split backend
         for (int input_id = 0; input_id < split->n_inputs; input_id++) {
+            if (input_id == lookahead_input_id) continue; // H2D already fired via lookahead
             ggml_backend_t input_backend = ggml_backend_sched_get_tensor_backend(sched, split->inputs[input_id]);
             struct ggml_tensor * input = split->inputs[input_id];
             struct ggml_tensor * input_cpy = tensor_copy(input, split_backend_id, sched->cur_copy);
@@ -1781,6 +1977,45 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     ggml_backend_event_wait(split_backend, sched->events[split_backend_id][sched->cur_copy]);
                 } else {
                     ggml_backend_synchronize(split_backend);
+                }
+
+                // mindcontrol-port: full-tensor prefetch for MoE expert weights during prefill.
+                // Only when NOT already handled by a lookahead fire for this split, and never in
+                // callback_eval mode (decode). With large batches virtually every expert is used,
+                // so the routing ids are not worth waiting for; uploads run through a second
+                // backend instance on the same device so they overlap compute, alternating
+                // between two staging slots.
+                if (sched->prefetch_experts && !sched->callback_eval && split_prefetch_slot == -1 && split->graph.n_nodes > 0) {
+                    ggml_tensor * node = split->graph.nodes[0];
+                    if (ggml_backend_buffer_get_usage(input->buffer) == GGML_BACKEND_BUFFER_USAGE_WEIGHTS &&
+                        node->op == GGML_OP_MUL_MAT_ID && node->src[0] == input_cpy) {
+                        const ggml_tensor * ids = node->src[2];
+                        const int64_t n_expert = input->ne[2];
+                        if (ids->ne[0]*ids->ne[1] >= 2*n_expert &&
+                            ggml_backend_sched_prefetch_init(sched, split_backend, ggml_nbytes(input))) {
+                            const int slot = sched->prefetch_cur;
+                            sched->prefetch_cur = (sched->prefetch_cur + 1) % sched->prefetch_n_slots;
+                            // wait for the previous user of this slot to finish computing
+                            if (sched->prefetch_used[slot]) {
+                                ggml_backend_event_wait(sched->prefetch_backend, sched->prefetch_free[slot]);
+                            }
+                            // point the staging copy at the slot only for the duration of
+                            // this split, so a fallback to the regular path on a later
+                            // eval can never see a dangling slot pointer
+                            prefetch_input_cpy    = input_cpy;
+                            prefetch_saved_buffer = input_cpy->buffer;
+                            prefetch_saved_data   = input_cpy->data;
+                            input_cpy->buffer = sched->prefetch_slots[slot];
+                            input_cpy->data   = ggml_backend_buffer_get_base(sched->prefetch_slots[slot]);
+                            ggml_backend_tensor_set_async(sched->prefetch_backend, input_cpy, input->data, 0, ggml_nbytes(input));
+                            ggml_backend_event_record(sched->prefetch_ready[slot], sched->prefetch_backend);
+                            // NOTE: no event_wait here — prefetch runs on separate stream and
+                            // overlaps with compute. The consumer side has its own event
+                            // synchronization right before graph launch to ensure data is ready.
+                            split_prefetch_slot = slot;
+                            continue;
+                        }
+                    }
                 }
 
                 // when offloading MoE weights, we can reduce the amount of data copied by copying only the experts that are used
@@ -1886,7 +2121,29 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         }
 
         if (!sched->callback_eval) {
+            // Cross-stream sync for a lookahead/inline-prefetched weight: wait until the
+            // H2D on the prefetch backend has completed before launching compute (mode 1).
+            if (split_prefetch_slot != -1) {
+                if (prefetch_wait_mode == 1) {
+                    ggml_backend_event_wait(split_backend, sched->prefetch_ready[split_prefetch_slot]);
+                } else if (prefetch_wait_mode >= 2) {
+                    pending_prefetch_slots.push_back(split_prefetch_slot);
+                    last_prefetch_split_backend = split_backend;
+                }
+            }
             enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph);
+            if (split_prefetch_slot != -1) {
+                // the kernels have captured the slot address at launch, safe to restore
+                ggml_backend_event_record(sched->prefetch_free[split_prefetch_slot], split_backend);
+                sched->prefetch_used[split_prefetch_slot] = true;
+                prefetch_input_cpy->buffer = prefetch_saved_buffer;
+                prefetch_input_cpy->data   = prefetch_saved_data;
+            }
+            // fire lookahead prefetch for a future split so the H2D overlaps this split's
+            // compute (LOOKAHEAD=0: skip — prefetch fires inline per split instead)
+            if (LOOKAHEAD > 0) {
+                try_fire_prefetch(split_id + 1 + LOOKAHEAD);
+            }
             if (ec != GGML_STATUS_SUCCESS) {
                 return ec;
             }
@@ -1934,6 +2191,14 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
         prev_backend_id = split_backend_id;
     }
 
+    // End-of-graph prefetch sync (wait_mode >= 2, debug): one wait per graph instead of
+    // one per split. Only the last MoE split's output actually needs syncing.
+    if (prefetch_wait_mode >= 2 && !pending_prefetch_slots.empty() && last_prefetch_split_backend) {
+        for (int slot : pending_prefetch_slots) {
+            ggml_backend_event_wait(last_prefetch_split_backend, sched->prefetch_ready[slot]);
+        }
+    }
+
     return GGML_STATUS_SUCCESS;
 }
 
@@ -1962,6 +2227,14 @@ ggml_backend_sched_t ggml_backend_sched_new(
 
     sched->n_backends = n_backends;
     sched->n_copies = parallel ? GGML_SCHED_MAX_COPIES : 1;
+
+    // mindcontrol-port: full-tensor MoE expert prefetch. Default off; enabled via
+    // --prefetch-experts-slots, which calls ggml_backend_sched_set_prefetch_experts_slots().
+    sched->prefetch_experts   = false;
+    sched->prefetch_lookahead = 0;
+    sched->prefetch_wait_mode = 0;
+    sched->prefetch_n_slots   = 2;
+    sched->prefetch_cur       = 0;
 
     // initialize hash table
     // FIXME: needs to be size*2 to account for leafs (do it in graph_split instead)
@@ -2009,6 +2282,22 @@ ggml_backend_sched_t ggml_backend_sched_new(
     return sched;
 }
 
+void ggml_backend_sched_set_prefetch_experts_slots(ggml_backend_sched_t sched, int slots) {
+    if (sched == NULL) { return; }
+    if (slots < 2) {
+        // 0 (off) or 1 (cannot pipeline) -> fully disabled
+        sched->prefetch_experts   = false;
+        sched->prefetch_lookahead = 0;
+        sched->prefetch_wait_mode = 0;
+        return;
+    }
+    if (slots > GGML_SCHED_MAX_PREFETCH_SLOTS) { slots = GGML_SCHED_MAX_PREFETCH_SLOTS; }
+    sched->prefetch_experts   = true;
+    sched->prefetch_n_slots   = slots;
+    sched->prefetch_lookahead = 1; // measured-optimal (mindcontrol prefetch-wait A/B verdict)
+    sched->prefetch_wait_mode = 1; // per-split wait: only mode that preserves tool_calls
+}
+
 void ggml_backend_sched_free(ggml_backend_sched_t sched) {
     if (sched == NULL) {
         return;
@@ -2017,6 +2306,14 @@ void ggml_backend_sched_free(ggml_backend_sched_t sched) {
         for (int c = 0; c < sched->n_copies; c++) {
             ggml_backend_event_free(sched->events[b][c]);
         }
+    }
+    for (int i = 0; i < sched->prefetch_n_slots; i++) {
+        if (sched->prefetch_slots[i]) { ggml_backend_buffer_free(sched->prefetch_slots[i]); }
+        if (sched->prefetch_ready[i]) { ggml_backend_event_free(sched->prefetch_ready[i]); }
+        if (sched->prefetch_free[i])  { ggml_backend_event_free(sched->prefetch_free[i]); }
+    }
+    if (sched->prefetch_backend) {
+        ggml_backend_free(sched->prefetch_backend);
     }
     ggml_gallocr_free(sched->galloc);
     ggml_free(sched->ctx);

--- a/include/llama.h
+++ b/include/llama.h
@@ -490,6 +490,12 @@ extern "C" {
                           // try to disable when n_seq_max > 1 for improved performance when the sequences do not share a large prefix
                           // ref: https://github.com/ggml-org/llama.cpp/pull/14363
 
+        // mindcontrol-port of --prefetch-experts-slots: MoE expert H2D staging slots.
+        // 0 = off (no memory overhead); >=2 enables full-tensor lookahead prefetch of
+        // host-resident (ncmoe) expert weights during prefill (GPU staging cost = slots
+        // * max expert tensor). Decode is unaffected.
+        int prefetch_experts_slots;  // set via llama_context_default_params() / llama_context_from_params
+
         // [EXPERIMENTAL]
         // backend sampler chain configuration (make sure the caller keeps the sampler chains alive)
         // note: the samplers must be sampler chains (i.e. use llama_sampler_chain_init)

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -578,6 +578,7 @@ llama_context::llama_context(
     }
 
     cparams.op_offload = params.op_offload;
+    cparams.prefetch_experts_slots = params.prefetch_experts_slots;
     cparams.kv_unified = params.kv_unified;
 
     // initialized later
@@ -964,6 +965,7 @@ void llama_context::sched_reserve() {
             backend_kvarn_workspace_split_k_size.end(), 0);
 
     sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
+    ggml_backend_sched_set_prefetch_experts_slots(sched.get(), cparams.prefetch_experts_slots);
 
     llama_memory_context_ptr mctx;
     if (memory) {
@@ -999,6 +1001,7 @@ void llama_context::sched_reserve() {
                 LLAMA_LOG_WARN("%s: compute buffer allocation failed, retrying without pipeline parallelism\n", __func__);
                 cparams.pipeline_parallel = false;
                 sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, false, cparams.op_offload));
+                ggml_backend_sched_set_prefetch_experts_slots(sched.get(), cparams.prefetch_experts_slots);
                 gf = graph_reserve(n_tokens, n_seqs, n_outputs_pp, mctx.get());
             }
             if (!gf) {
@@ -4369,6 +4372,7 @@ llama_context_params llama_context_default_params() {
         /*.op_offload                  =*/ true,
         /*.swa_full                    =*/ true,
         /*.kv_unified                  =*/ false,
+        /*.prefetch_experts_slots      =*/ 0,
         /*.sampler                     =*/ nullptr,
         /*.n_sampler                   =*/ 0,
         /*.ctx_other                   =*/ nullptr,

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -54,6 +54,8 @@ struct llama_cparams {
     bool kv_unified;
     bool pipeline_parallel;
 
+    int prefetch_experts_slots = 0; // --prefetch-experts-slots: MoE expert H2D staging slots (0 = off, >=2 enables full-tensor lookahead prefetch; capped at 4)
+
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 
     enum llama_context_type ctx_type;


### PR DESCRIPTION
# PR body — `--prefetch-experts-slots`: lookahead H2D prefetch of host-resident MoE expert weights

**Branch:** `feat/prefetch-experts-slots` — commit `e502dd002` on top of `v0.4.5` (`99be96e2e`)
**Scope:** 8 files, +327 / −0, **this feature only** (no other changes ride along)

## What it does

When a MoE model's expert weights are **not** GPU-resident (`--n-cpu-moe N`, or
auto-offload with a fit margin such that part of the model streams from host RAM),
every prefill batch forces the scheduler to upload each used expert tensor
host→device **right before** the `MUL_MAT_ID` split that consumes it. That H2D
transfer sits on the critical path and serializes behind the compute of the
previous split, so large-batch prefill (prompt processing) is dominated by
waiting on PCIe/NVLink instead of by kernels.

This PR makes those uploads overlap compute. During prefill it fires full-tensor
H2D copies **ahead of need** through a **second backend instance on the same
device** into **rotating staging buffers**, and the consuming split performs a
per-split cross-stream event wait that — because the copy was fired one split
earlier — is already satisfied by launch time.

```
split i        :  [ MUL_MAT_ID compute on expert weights ]
                    ^ uploads for split i+2 fired here (1-deep lookahead)
prefetch stream:     |======= H2D expert(i+2) into staging slot =======|
split i+2      :  [ wait ready[i+2] (no-op) ]  [ MUL_MAT_ID compute ]
```

## User-visible surface

- `--prefetch-experts-slots N` — **default `0` = off, zero memory overhead.**
  `N >= 2` enables the pipeline (needs at least 2 slots to rotate); `3` is
  recommended, `4` is the cap.
- GPU memory cost: `N × max_expert_tensor`, lazy-allocated on first fire.
- Optionally: `llama_context_params.prefetch_experts_slots` /
  `ggml_backend_sched_set_prefetch_experts_slots()` for library users.

## How it works (mechanism)

`ggml_backend_sched` gains a small prefetch state machine
(`ggml/src/ggml-backend.cpp`):

1. **Gate** — only fires for splits whose first node is `GGML_OP_MUL_MAT_ID`,
   whose expert weight input is host-resident with
   `GGML_BACKEND_BUFFER_USAGE_WEIGHTS`, and whose routed batch is prefill-scale
   (`ids ≥ 2 × n_expert`). In `callback_eval` mode (decode, MTP draft) it never
   fires — **decode is unaffected by construction**.
2. **Staging** — a second backend instance (`ggml_backend_dev_init` on the same
   device, only if the device advertises `async` + `events` caps) uploads the
   *full* expert tensor into slot buffers via `ggml_backend_tensor_set_async`.
   With a large batch essentially every expert is used, so routing ids carry no
   information worth waiting for — full-tensor prefetch is the right trade.
3. **Lookahead** — while split `i` computes, the copy for split `i + 1 + LOOKAHEAD`
   is already in flight (`LOOKAHEAD = 1`).
4. **Sync** — each staged split does one `ggml_backend_event_wait(ready[slot])`
   on its backend right before graph launch. Because of the lookahead this is a
   no-op in steady state; it is the *only* synchronization point that preserves
   tool-call/`tool_choice` semantics (an earlier one-wait-per-graph variant was
   dropped for that reason).
5. **Safety** — the staged copy is only re-pointed at the slot buffer for the
   duration of its split and restored right after launch (kernels have already
   captured the address), so any fallback path can never observe a dangling
   slot. On any allocation/cap failure prefetch disables itself and the regular
   copy path is used — correctness never depends on prefetch.

The only user-visible knob is the slot count: lookahead depth and wait mode are
hardcoded to their measured-optimal values.

## Lossless

**Prefetch changes *when* bytes arrive on device, never *what* is computed:**

- **slots = 0 (default):** the setter fully disables the feature — no state, no
  allocations, and the scheduler's compute loop behaves exactly as before.
- **slots ≥ 2:** the copied bytes are the same host weights; the consuming graph
  is unchanged (same tensors, same kernels, same order); the ready-event wait
  guarantees the data is on device before launch, making the overlap invisible
  to the numerics. The only mutation is a temporary re-point of the input copy's
  buffer/data pointer, restored before the next eval.
- No sampler, graph, or scheduling-order changes of any kind.

**Empirical evidence** (mindport build, greedy `temperature 0`, identical
prompt/seed, `--n-cpu-moe 20` on a 24B A3B, q4_0 KV cache):

| run | TTFT (prompt_ms) | output |
|---|---|---|
| prefetch OFF | 3501 | 682 chars |
| prefetch ON (slots 3) | 3786 | 682 chars |
| **byte-identical:** | | **True** |

## Measured effect (host-expert configs)

Large prefill batches are where the feature pays; decode is untouched by design.

| config | prompt | TTFT OFF | TTFT ON | decode OFF→ON | recall |
|---|---|---|---|---|---|
| 24B A3B, `-ncmoe 20` | ~42k tok (ctx 60k) | 15.71 s | **13.97 s (−11%)** | 45.8 → 46.0 t/s | 20/20 both |
| 24B A3B, `-ncmoe 20` | 200 tok (ctx 4k) | 0.51 s | **0.41 s (−20%)** | 73.8 → 74.6 t/s | 19/20 both |
| 21.8 GB 35B A3B Q4_K_M, auto-offload | ~42k tok | 21.19 s | **16.46 s (−22%)** | 41.8 → 41.5 t/s | 20/20 both |
| 21.8 GB 35B A3B Q4_K_M, auto-offload | 200 tok | 0.76 s | 1.64 s (regression) | 61.5 → 62.6 t/s | 17/20 both |

Notes: on the 35B no `-ncmoe` was used — the auto-offload fit margin
(`-fitt 700`) alone leaves ~half the expert weights host-resident, which is the
realistic deployment this feature targets. At 200 tokens the ON arm's 0.76→1.64 s
TTFT is the staging fixed cost dominating a tiny prefill — the feature is aimed
at large batches and is simply off by default for everyone else. Recall/outputs
are identical across arms in every row.

## Files

| file | change |
|---|---|
| `common/arg.cpp` | `--prefetch-experts-slots N` flag |
| `common/common.{h,cpp}` | `common_params.prefetch_experts_slots` plumbing |
| `include/llama.h`, `src/llama-cparams.h` | cparams field + default (`0`) |
| `src/llama-context.cpp` | wire cparams → `sched_reserve()` |
| `ggml/include/ggml-backend.h`, `ggml/src/ggml-backend.cpp` | scheduler prefetch state machine (+297) |
