### PR TITLE
kv cache: retain final compact-tail slot writes

### DIFF
--- a/src/llama-kv-cache-tail.cpp
+++ b/src/llama-kv-cache-tail.cpp
@@ -12,9 +12,9 @@
 void llama_kv_tail_keep_last_writes(int64_t * indices, uint32_t n_tokens, uint32_t n_levels) {
     std::unordered_set<int64_t> written;
     written.reserve(n_tokens);
-    for (uint32_t level = 0; level < n_levels; ++level) {
-        written.clear();
-        for (uint32_t row = n_tokens; row-- > 0;) {
+    // Commits are ordered by token, then owner (level), not by graph op.
+    for (uint32_t row = n_tokens; row-- > 0;) {
+        for (uint32_t level = n_levels; level-- > 0;) {
             auto & slot = indices[size_t(level)*n_tokens + row];
             if (slot >= 0 && !written.insert(slot).second) {
                 slot = -1;

--- a/src/llama-kv-cache-tail.cpp
+++ b/src/llama-kv-cache-tail.cpp
@@ -9,6 +9,20 @@
 #include <string>
 #include <unordered_set>
 
+void llama_kv_tail_keep_last_writes(int64_t * indices, uint32_t n_tokens, uint32_t n_levels) {
+    std::unordered_set<int64_t> written;
+    written.reserve(n_tokens);
+    for (uint32_t level = 0; level < n_levels; ++level) {
+        written.clear();
+        for (uint32_t row = n_tokens; row-- > 0;) {
+            auto & slot = indices[size_t(level)*n_tokens + row];
+            if (slot >= 0 && !written.insert(slot).second) {
+                slot = -1;
+            }
+        }
+    }
+}
+
 size_t llama_kv_tail_store::identity_hash::operator()(const llama_kv_tail_identity & value) const {
     size_t hash = value.stream;
     hash = hash * 0x9e3779b1u + value.cell;

--- a/src/llama-kv-cache-tail.h
+++ b/src/llama-kv-cache-tail.h
@@ -19,7 +19,7 @@
 constexpr int32_t LLAMA_KV_TAIL_BODY_SLOT = -1;
 
 // SET_ROWS requires unique destinations. Indices are [level][token]; retain
-// only the last write to each slot in each level, leaving negative skips intact.
+// only the globally last (token, level) write to each slot; preserve negative skips.
 void llama_kv_tail_keep_last_writes(int64_t * indices, uint32_t n_tokens, uint32_t n_levels);
 
 struct llama_kv_tail_identity {

--- a/src/llama-kv-cache-tail.h
+++ b/src/llama-kv-cache-tail.h
@@ -18,6 +18,10 @@
 
 constexpr int32_t LLAMA_KV_TAIL_BODY_SLOT = -1;
 
+// SET_ROWS requires unique destinations. Indices are [level][token]; retain
+// only the last write to each slot in each level, leaving negative skips intact.
+void llama_kv_tail_keep_last_writes(int64_t * indices, uint32_t n_tokens, uint32_t n_levels);
+
 struct llama_kv_tail_identity {
     uint32_t stream;
     uint32_t cell;

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -3635,6 +3635,13 @@ void llama_kv_cache::set_input_tail_idxs(ggml_tensor * dst, const llama_ubatch *
     GGML_ASSERT(uint32_t(dst->ne[1]) == tail_write_levels);
     GGML_ASSERT(tail_write_slots.size() == size_t(ubatch->n_tokens)*tail_write_levels);
     std::memcpy(dst->data, tail_write_slots.data(), tail_write_slots.size()*sizeof(int64_t));
+    if (has_compact_tail()) {
+        // A batch can recycle compact slots several times. The tail is updated
+        // after attention, so only the final occupant needs to be stored.
+        // Passing all writes to SET_ROWS races on both CPU and GPU backends.
+        llama_kv_tail_keep_last_writes(
+                static_cast<int64_t *>(dst->data), ubatch->n_tokens, tail_write_levels);
+    }
 }
 
 void llama_kv_cache::set_input_tail_body_idxs(ggml_tensor * dst) const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -345,6 +345,8 @@ llama_build(test-save-load-state.cpp)
 
 if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     # these tests are disabled on Windows because they use internal functions not exported with LLAMA_API (when building with shared libraries)
+    llama_build_and_test(test-kv-tail-input.cpp)
+    target_include_directories(test-kv-tail-input PRIVATE ${PROJECT_SOURCE_DIR}/src)
     llama_build_and_test(test-unicode.cpp)
     llama_build_and_test(test-sampling.cpp)
     llama_build_and_test(test-reasoning-budget.cpp)

--- a/tests/test-kv-tail-input.cpp
+++ b/tests/test-kv-tail-input.cpp
@@ -1,0 +1,68 @@
+#include "llama-kv-cache.h"
+#include "llama-model.h"
+#include "ggml-backend.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+static void check(bool ok, const char * message) {
+    if (!ok) {
+        std::fprintf(stderr, "%s\n", message);
+        std::exit(1);
+    }
+}
+
+int main() {
+    ggml_backend_load_all();
+    auto backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    check(backend != nullptr, "CPU backend unavailable");
+    std::unique_ptr<llama_model> model(llama_model_create(LLM_ARCH_LLAMA, llama_model_default_params()));
+    // No model tensors: exercise the same metadata cache used by structured caches.
+    llama_kv_cache cache(*model, model->hparams, GGML_TYPE_F16, GGML_TYPE_F16,
+            false, false, true, 32, 2, 1, 0, LLAMA_SWA_TYPE_NONE,
+            nullptr, {}, {}, {}, 4, 2, GGML_TYPE_F16, 2, true, 0);
+    check(cache.has_compact_tail(), "fixture must use a compact tail");
+    llama_kv_tail_layer_route route = {};
+    route.capability.supported = true;
+    route.capability.route = LLAMA_KV_TAIL_ROUTE_NATIVE;
+    cache.set_tail_routes({route});
+    cache.finalize_tail_overlay_metadata();
+
+    llama_pos positions[] = {0, 1, 2, 3};
+    int32_t counts[] = {2, 1, 1, 1};
+    llama_seq_id owners[] = {1, 0};
+    llama_seq_id * seqs[] = {owners, owners + 1, owners + 1, owners + 1};
+    llama_ubatch batch = {};
+    batch.n_tokens = 4;
+    batch.n_pos = 1;
+    batch.pos = positions;
+    batch.n_seq_id = counts;
+    batch.seq_id = seqs;
+    llama_kv_cache::slot_info slots = {};
+    slots.strm = {0};
+    slots.idxs = {{0, 1, 2, 3}};
+    cache.apply_ubatch(slots, batch);
+
+    auto ctx = ggml_init({1024*1024, nullptr, true});
+    auto indices = cache.build_input_tail_idxs(ctx, batch);
+    check(indices && indices->ne[1] == 2, "fixture must produce two owner levels");
+    auto buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    check(buffer != nullptr, "input allocation failed");
+    cache.set_input_tail_idxs(indices, &batch);
+    std::vector<int64_t> got(8);
+    ggml_backend_tensor_get(indices, got.data(), 0, got.size()*sizeof(int64_t));
+    // Level 1/row 0 and level 0/row 2 reuse slot 0. Only row 2 persists.
+    check(got[2] == 0 && got[3] == 1 && got[4] == -1,
+            "production input did not retain the globally last slot write");
+    for (size_t i = 0; i < got.size(); ++i) {
+        if (got[i] < 0) continue;
+        for (size_t j = i + 1; j < got.size(); ++j) {
+            check(got[i] != got[j], "production input retained duplicate destinations");
+        }
+    }
+    cache.finish_tail_batch(true, false);
+    ggml_backend_buffer_free(buffer);
+    ggml_free(ctx);
+    ggml_backend_free(backend);
+}

--- a/tests/test-std-kv-tail-graph.cpp
+++ b/tests/test-std-kv-tail-graph.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <unordered_set>
 #include <vector>
 
 [[noreturn]] static void fail(const char * message) {
@@ -915,6 +916,135 @@ static void test_sparse_swa_packed_oracle(ggml_backend_t backend, llama_swa_type
     ggml_free(ctx);
 }
 
+static void test_cpu_set_rows_last_write_filter() {
+    constexpr uint32_t n_tokens = 512;
+    constexpr uint32_t n_slots = 129;
+    constexpr uint32_t n_levels = 2;
+    constexpr int64_t width = 4;
+
+    ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
+    if (!backend) {
+        fail("failed to initialize CPU backend for duplicate tail-write test");
+    }
+    ggml_backend_dev_t device = ggml_backend_get_device(backend);
+    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(device);
+    auto set_n_threads = (ggml_backend_set_n_threads_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_set_n_threads");
+    if (!set_n_threads) {
+        fail("CPU backend has no thread-count control for duplicate tail-write test");
+    }
+    set_n_threads(backend, 8);
+
+    ggml_init_params params = { 16*1024*1024, nullptr, true };
+    ggml_context * ctx = ggml_init(params);
+    ggml_tensor * storage = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, width, n_slots);
+    ggml_tensor * source = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, width, n_tokens);
+    ggml_tensor * indices = ggml_new_tensor_2d(ctx, GGML_TYPE_I64, n_tokens, n_levels);
+    ggml_tensor * write = nullptr;
+    for (uint32_t level = 0; level < n_levels; ++level) {
+        ggml_tensor * level_indices = ggml_view_1d(
+                ctx, indices, n_tokens, size_t(level)*indices->nb[1]);
+        write = ggml_set_rows_ordered(ctx, storage, source, level_indices, write);
+    }
+    ggml_tensor * lhs = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, width, width);
+    ggml_tensor * rhs = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, width, width);
+    ggml_tensor * dummy = ggml_mul_mat(ctx, lhs, rhs);
+    ggml_cgraph * graph = ggml_new_graph(ctx);
+    ggml_build_forward_expand(graph, write);
+    ggml_build_forward_expand(graph, dummy);
+    ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+    if (!buffer) {
+        fail("failed to allocate duplicate tail-write graph tensors");
+    }
+
+    std::vector<int64_t> original(size_t(n_tokens)*n_levels);
+    for (uint32_t level = 0; level < n_levels; ++level) {
+        for (uint32_t row = 0; row < n_tokens; ++row) {
+            // Interleave the two slot streams and include body skips.
+            int64_t slot = int64_t((2*row + level) % n_slots);
+            if ((row + 17*level) % 67 == 0) {
+                slot = LLAMA_KV_TAIL_BODY_SLOT;
+            }
+            original[size_t(level)*n_tokens + row] = slot;
+        }
+    }
+    std::vector<float> source_data(size_t(width)*n_tokens);
+    for (uint32_t row = 0; row < n_tokens; ++row) {
+        for (int64_t col = 0; col < width; ++col) {
+            source_data[size_t(row)*width + col] = float(row + 1);
+        }
+    }
+
+    std::vector<float> expected(n_slots, -777.0f);
+    for (uint32_t level = 0; level < n_levels; ++level) {
+        for (uint32_t row = 0; row < n_tokens; ++row) {
+            const int64_t slot = original[size_t(level)*n_tokens + row];
+            if (slot >= 0) {
+                expected[size_t(slot)] = float(row + 1);
+            }
+        }
+    }
+    std::vector<int64_t> filtered = original;
+    llama_kv_tail_keep_last_writes(filtered.data(), n_tokens, n_levels);
+    for (uint32_t level = 0; level < n_levels; ++level) {
+        std::unordered_set<int64_t> expected_live;
+        std::unordered_set<int64_t> live;
+        for (uint32_t row = 0; row < n_tokens; ++row) {
+            const int64_t before = original[size_t(level)*n_tokens + row];
+            const int64_t after = filtered[size_t(level)*n_tokens + row];
+            if (before < 0) {
+                if (after != before) fail("tail-write filter changed a negative skip");
+            } else {
+                expected_live.insert(before);
+                if (after >= 0 && !live.insert(after).second) {
+                    fail("tail-write filter retained a duplicate");
+                }
+            }
+        }
+        if (live.size() != expected_live.size()) {
+            fail("tail-write filter changed the number of live slots");
+        }
+    }
+
+    const int64_t encoded[] = {
+        (int64_t(1) << 32) | 3, (int64_t(2) << 32) | 7, (int64_t(1) << 32) | 3,
+        -1, (int64_t(2) << 32) | 7, (int64_t(3) << 32) | 1,
+    };
+    int64_t encoded_copy[6];
+    std::memcpy(encoded_copy, encoded, sizeof(encoded));
+    llama_kv_tail_keep_last_writes(encoded_copy, 3, 2);
+    if (encoded_copy[0] != -1 || encoded_copy[1] != encoded[1] ||
+            encoded_copy[2] != encoded[2] || encoded_copy[3] != -1 ||
+            encoded_copy[4] != encoded[4] || encoded_copy[5] != encoded[5]) {
+        fail("tail-write filter mishandled interleaved encoded slots");
+    }
+
+    std::vector<ggml_fp16_t> initial(size_t(width)*n_slots, ggml_fp32_to_fp16(-777.0f));
+    ggml_backend_tensor_set(storage, initial.data(), 0, initial.size()*sizeof(ggml_fp16_t));
+    ggml_backend_tensor_set(source, source_data.data(), 0, source_data.size()*sizeof(float));
+    ggml_backend_tensor_set(indices, filtered.data(), 0, filtered.size()*sizeof(int64_t));
+    std::vector<float> zeros(ggml_nelements(lhs), 0.0f);
+    ggml_backend_tensor_set(lhs, zeros.data(), 0, ggml_nbytes(lhs));
+    ggml_backend_tensor_set(rhs, zeros.data(), 0, ggml_nbytes(rhs));
+    if (ggml_backend_graph_compute(backend, graph) != GGML_STATUS_SUCCESS) {
+        fail("duplicate tail-write graph compute failed");
+    }
+    std::vector<ggml_fp16_t> got_f16(ggml_nelements(storage));
+    std::vector<float> got(got_f16.size());
+    ggml_backend_tensor_get(storage, got_f16.data(), 0, got_f16.size()*sizeof(ggml_fp16_t));
+    ggml_fp16_to_fp32_row(got_f16.data(), got.data(), got.size());
+    for (uint32_t slot = 0; slot < n_slots; ++slot) {
+        for (int64_t col = 0; col < width; ++col) {
+            if (got[size_t(slot)*width + col] != expected[slot]) {
+                fail("CPU mixed graph did not preserve sequential last tail write");
+            }
+        }
+    }
+    ggml_backend_buffer_free(buffer);
+    ggml_backend_free(backend);
+    ggml_free(ctx);
+}
+
 int main() {
     test_representation_topology();
     ggml_backend_load_all();
@@ -925,6 +1055,7 @@ int main() {
     test_attention_graph(backend);
     test_shadow_roundtrip(backend);
     ggml_backend_free(backend);
+    test_cpu_set_rows_last_write_filter();
 
     ggml_backend_dev_t cpu = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
     if (!cpu) {

--- a/tests/test-std-kv-tail-graph.cpp
+++ b/tests/test-std-kv-tail-graph.cpp
@@ -916,10 +916,9 @@ static void test_sparse_swa_packed_oracle(ggml_backend_t backend, llama_swa_type
     ggml_free(ctx);
 }
 
-static void test_cpu_set_rows_last_write_filter() {
+static void test_cpu_set_rows_last_write_filter(uint32_t n_levels) {
     constexpr uint32_t n_tokens = 512;
     constexpr uint32_t n_slots = 129;
-    constexpr uint32_t n_levels = 2;
     constexpr int64_t width = 4;
 
     ggml_backend_t backend = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
@@ -976,8 +975,8 @@ static void test_cpu_set_rows_last_write_filter() {
     }
 
     std::vector<float> expected(n_slots, -777.0f);
-    for (uint32_t level = 0; level < n_levels; ++level) {
-        for (uint32_t row = 0; row < n_tokens; ++row) {
+    for (uint32_t row = 0; row < n_tokens; ++row) {
+        for (uint32_t level = 0; level < n_levels; ++level) {
             const int64_t slot = original[size_t(level)*n_tokens + row];
             if (slot >= 0) {
                 expected[size_t(slot)] = float(row + 1);
@@ -986,37 +985,14 @@ static void test_cpu_set_rows_last_write_filter() {
     }
     std::vector<int64_t> filtered = original;
     llama_kv_tail_keep_last_writes(filtered.data(), n_tokens, n_levels);
-    for (uint32_t level = 0; level < n_levels; ++level) {
-        std::unordered_set<int64_t> expected_live;
-        std::unordered_set<int64_t> live;
-        for (uint32_t row = 0; row < n_tokens; ++row) {
-            const int64_t before = original[size_t(level)*n_tokens + row];
-            const int64_t after = filtered[size_t(level)*n_tokens + row];
-            if (before < 0) {
-                if (after != before) fail("tail-write filter changed a negative skip");
-            } else {
-                expected_live.insert(before);
-                if (after >= 0 && !live.insert(after).second) {
-                    fail("tail-write filter retained a duplicate");
-                }
-            }
+    std::unordered_set<int64_t> live;
+    for (size_t i = 0; i < filtered.size(); ++i) {
+        if (original[i] < 0 && filtered[i] != original[i]) {
+            fail("tail-write filter changed a negative skip");
         }
-        if (live.size() != expected_live.size()) {
-            fail("tail-write filter changed the number of live slots");
+        if (filtered[i] >= 0 && !live.insert(filtered[i]).second) {
+            fail("tail-write filter retained a cross-level duplicate");
         }
-    }
-
-    const int64_t encoded[] = {
-        (int64_t(1) << 32) | 3, (int64_t(2) << 32) | 7, (int64_t(1) << 32) | 3,
-        -1, (int64_t(2) << 32) | 7, (int64_t(3) << 32) | 1,
-    };
-    int64_t encoded_copy[6];
-    std::memcpy(encoded_copy, encoded, sizeof(encoded));
-    llama_kv_tail_keep_last_writes(encoded_copy, 3, 2);
-    if (encoded_copy[0] != -1 || encoded_copy[1] != encoded[1] ||
-            encoded_copy[2] != encoded[2] || encoded_copy[3] != -1 ||
-            encoded_copy[4] != encoded[4] || encoded_copy[5] != encoded[5]) {
-        fail("tail-write filter mishandled interleaved encoded slots");
     }
 
     std::vector<ggml_fp16_t> initial(size_t(width)*n_slots, ggml_fp32_to_fp16(-777.0f));
@@ -1055,7 +1031,8 @@ int main() {
     test_attention_graph(backend);
     test_shadow_roundtrip(backend);
     ggml_backend_free(backend);
-    test_cpu_set_rows_last_write_filter();
+    test_cpu_set_rows_last_write_filter(1);
+    test_cpu_set_rows_last_write_filter(2);
 
     ggml_backend_dev_t cpu = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
     if (!cpu) {


### PR DESCRIPTION
## Overview

Compact KV precision tails can recycle the same destination slot more than once within a single ubatch. `llama_kv_cache::set_input_tail_idxs()` previously passed all of those duplicate destinations to `GGML_OP_SET_ROWS`. In a mixed CPU graph the operation runs with the graph-wide thread count, so writes to the same row race and the final stored value is nondeterministic. This corrupts the persistent exact tail and causes a large CPU-only KVarN quality regression at larger ubatches.

This change filters only the copied graph-input indices, across all tail levels. A reverse scan in (token, level) commit order retains the final nonnegative write to every slot and converts earlier duplicate writes to `-1`; existing negative skip values and the logical tail schedule remain unchanged. The tail update happens after attention, so the final occupant is the value that must persist for the next decode.

The regression test models the observed wraparound with 512 tokens, 129 tail slots, one and two tail levels, and an eight-thread mixed CPU graph. Its oracle follows logical commit order. A separate metadata-only cache fixture drives apply_ubatch(), build_input_tail_idxs(), and set_input_tail_idxs() for a four-token/two-owner wraparound case. This integration test fails if the production filter call is removed or the old per-level filtering is restored.

## Additional information

KLD was re-measured using the unpatched `v0.4.7` commit `8b59e71ba39dc0d47df6b3a33f4fd6b1743dbd7a` and PR head `4624e4b27f0e9a0941deda7530742422628b77a7`. The hardware was an NVIDIA GeForce RTX 5060 Ti and AMD Ryzen 7 5700X3D with 8 inference threads / 16 logical CPUs, using Windows, MSVC 19.51.36256.0, CUDA architecture 1200, CUDA, FlashAttention, KVarN, and native CPU optimizations. The model was `unsloth/Qwen3.8-27B-UD-IQ3_XXS.gguf`; the corpus was one 32,768-token chunk from WikiText-2 raw.

A fresh BF16 baseline was generated from the unpatched commit:

```text
llama-perplexity -m Qwen3.8-27B-UD-IQ3_XXS.gguf -f wiki.test.raw -c 32768 -b 512 -ub 512 --flash-attn on -ctk bf16 -ctv bf16 -ngl 99 -fit off --no-warmup --kl-divergence-base Qwen3.8-27B-bee-baseline_IQ3_XXS_32768_b512_1.kld --log-verbosity 4 --chunks 1
```

All KVarN runs used this command, differing only in revision and `-ngl`:

```text
llama-perplexity -m Qwen3.8-27B-UD-IQ3_XXS.gguf -f wiki.test.raw -c 32768 -b 512 -ub 512 --flash-attn on -ctk kvarn4 -ctv kvarn4 -ngl {0|99} -fit off --no-warmup --kl-divergence-base Qwen3.8-27B-bee-baseline_IQ3_XXS_32768_b512_1.kld --kl-divergence --log-verbosity 4
```

| Revision / placement | Mean KLD | Maximum KLD | 99.9% KLD | Mean PPL | Same top p |
| --- | ---: | ---: | ---: | ---: | ---: |
| `8b59e71ba`, CUDA (`-ngl 99`) | 0.001342 ± 0.000023 | 0.122390 | 0.036053 | 6.173581 | 98.224 ± 0.103% |
| `8b59e71ba`, CPU (`-ngl 0`) | 0.012217 ± 0.000922 | 6.337698 | 1.995899 | 6.230974 | 96.875 ± 0.136% |
| `4624e4b`, CUDA (`-ngl 99`) | 0.001342 ± 0.000023 | 0.122390 | 0.036053 | 6.173581 | 98.224 ± 0.103% |
| `4624e4b`, CPU (`-ngl 0`) | 0.001350 ± 0.000032 | 0.397151 | 0.027932 | 6.173747 | 98.163 ± 0.105% |

The fix reduces mean CPU KLD from 0.012217 to 0.001350 and restores CPU quality to the CUDA range. CUDA statistics are identical before and after the change.

Validation after integrating `v0.4.7` at `8b59e71ba39dc0d47df6b3a33f4fd6b1743dbd7a`:

```text
cmake -S . -B build-static-review -G "Visual Studio 18 2026" -A x64 -DBUILD_SHARED_LIBS=OFF -DGGML_CUDA=OFF -DGGML_NATIVE=ON
cmake --build build-static-review --config Release --target test-kv-tail-input test-std-kv-tail-graph test-kv-cache-tail test-kv-tail-request test-fit-kvarn-tail test-kv-tail-copy-transaction --parallel 4
ctest --test-dir build-static-review -C Release -R "^(test-kv-tail-input|test-std-kv-tail-graph|test-kv-cache-tail|test-kv-tail-request|test-fit-kvarn-tail|test-kv-tail-copy-transaction|test-std-kv-tail-static|test-kvarn-hip-tail-capability-static)$" --output-on-failure
```

All eight tests passed. The integration test uses internal APIs and therefore requires a static build on Windows, following the existing test convention. Negative indices remain confined to the compact-tail path; the shadow path is unchanged.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — OpenAI Codex assisted with root-cause analysis, implementation, regression testing, and drafting this description.
