### PR TITLE
perplexity: honor larger batch size for KLD processing

### DIFF
--- a/tests/test-perplexity-plumbing.cpp
+++ b/tests/test-perplexity-plumbing.cpp
@@ -45,12 +45,18 @@ int main(int argc, char ** argv) {
 
     const std::string root = argv[1];
     const std::string perplexity = read_file(root + "/tools/perplexity/perplexity.cpp");
+    const std::string ppl = slice_between(perplexity,
+            "static results_perplexity perplexity(llama_context * ctx, const common_params & params, const int32_t n_ctx)",
+            "static bool decode_helper");
     const std::string kl = slice_between(perplexity,
             "static bool kl_divergence(llama_context * ctx, const common_params & params)",
             "if (kld.count < 100) return true;");
 
     ok &= expect(perplexity.find("static int ppl_max_logits_rows(int n_vocab, const common_params & params)") != std::string::npos,
         "perplexity must cap full-vocab logits rows to avoid multi-GiB output buffers");
+    ok &= expect(ppl.find("const int max_logits_rows = params.logits_file.empty()") != std::string::npos &&
+                 ppl.find(": std::max(1, std::min(n_ctx, params.n_batch))") != std::string::npos,
+        "logits baseline generation must bypass the ordinary perplexity row cap");
     ok &= expect(perplexity.find("logits_stream.write(\"_logits_\", 8)") != std::string::npos,
         "perplexity must write upstream-compatible v1 logits baselines");
     ok &= expect(perplexity.find("kld_logits::") == std::string::npos,
@@ -61,14 +67,14 @@ int main(int argc, char ** argv) {
         "KLD must retain the upstream v1 probability cutoff");
     ok &= expect(perplexity.find("if (!kl_divergence(ctx, params))") != std::string::npos,
         "perplexity KL failures must propagate to a nonzero process exit");
-    ok &= expect(kl.find("const int max_logits_rows = ppl_max_logits_rows(n_vocab, params)") != std::string::npos,
-        "KL divergence must use the bounded logits-row cap");
-    ok &= expect(kl.find("const int n_batch = std::max(1, std::min(n_ctx_i, std::min(params.n_batch, max_logits_rows)))") != std::string::npos,
-        "KL divergence batch size must be bounded by max_logits_rows");
+    ok &= expect(kl.find("ppl_max_logits_rows") == std::string::npos,
+        "KL divergence must not silently cap the requested batch by logits memory");
+    ok &= expect(kl.find("const int n_batch = std::max(1, std::min(n_ctx_i, params.n_batch))") != std::string::npos,
+        "KL divergence batch size must honor the requested batch size");
     ok &= expect(kl.find("llama_batch_init(n_batch, 0, 1)") != std::string::npos,
         "KL divergence batch allocation must match bounded n_batch");
-    ok &= expect(kl.find("std::vector<uint16_t> log_probs_uint16(size_t(max_logits_rows) * nv)") != std::string::npos,
-        "KL divergence base-logit buffer must be bounded by max_logits_rows");
+    ok &= expect(kl.find("std::vector<uint16_t> log_probs_uint16(size_t(n_batch) * nv)") != std::string::npos,
+        "KL divergence base-logit buffer must match the decode batch size");
     ok &= expect(kl.find("const int logits_first = std::max(first, pos_start)") != std::string::npos &&
                  kl.find("const int logits_end   = std::min(n_ctx_i - 1, pos_start + batch_size)") != std::string::npos,
         "KL divergence must process only the logits rows produced by the current decode slice");

--- a/tools/perplexity/README.md
+++ b/tools/perplexity/README.md
@@ -22,6 +22,17 @@ and finally the `--kl-divergence` argument to indicate that the program should c
 This is a measure of how similar the FP16 and the quantized logit distributions are with a value of 0 indicating that the distribution are the same.
 The uncertainty on the mean KL divergence is calculated by assuming the KL divergence per token follows a Gaussian distribution.
 
+KL-divergence baselines and candidates are processed in blocks controlled by
+`--batch-size`; `--ubatch-size` controls how those blocks are split internally.
+The F32 logits output requires `vocabulary size * batch size * 4` bytes of host
+memory. KL-divergence evaluation also keeps a compressed baseline block that
+requires roughly half as much memory. Use matching `--batch-size` and
+`--ubatch-size` settings when generating a baseline and evaluating a candidate.
+
+For example, a model with 248320 vocabulary entries and a batch size of 2048
+uses 1940 MiB for the F32 logits block and about 970 MiB for the compressed
+baseline block.
+
 In addition to the KL divergence the following statistics are calculated with `--kl-divergence`:
 
 * Ratio of mean FP16 PPL and quantized PPL. Uncertainty is estimated on logits, then propagated. The logarithm of this metric is also calculated and printed, it is 0 if the logit distributions are the same.

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -518,7 +518,9 @@ static results_perplexity perplexity(llama_context * ctx, const common_params & 
     const int n_chunk_max = tokens.size() / n_ctx;
 
     const int n_vocab = llama_vocab_n_tokens(vocab);
-    const int max_logits_rows = ppl_max_logits_rows(n_vocab, params);
+    const int max_logits_rows = params.logits_file.empty()
+            ? ppl_max_logits_rows(n_vocab, params)
+            : std::max(1, std::min(n_ctx, params.n_batch));
     const int n_seq_ctx = std::max(1, params.n_ctx / n_ctx);
     const int n_seq = params.logits_file.empty() ? std::min(n_seq_ctx, max_logits_rows) : 1;
     const int n_batch = std::max(1, std::min(n_ctx, std::min(
@@ -1796,8 +1798,7 @@ static bool kl_divergence(llama_context * ctx, const common_params & params) {
     }
 
     const int n_ctx_i = static_cast<int>(n_ctx);
-    const int max_logits_rows = ppl_max_logits_rows(n_vocab, params);
-    const int n_batch = std::max(1, std::min(n_ctx_i, std::min(params.n_batch, max_logits_rows)));
+    const int n_batch = std::max(1, std::min(n_ctx_i, params.n_batch));
     const int num_batches = (n_ctx_i + n_batch - 1) / n_batch;
     const int n_seq = 1;
     const int nv = 2*((n_vocab + 1)/2) + 4;
@@ -1806,7 +1807,7 @@ static bool kl_divergence(llama_context * ctx, const common_params & params) {
 
     llama_batch batch = llama_batch_init(n_batch, 0, 1);
 
-    std::vector<uint16_t> log_probs_uint16(size_t(max_logits_rows) * nv);
+    std::vector<uint16_t> log_probs_uint16(size_t(n_batch) * nv);
     std::vector<float>    kld_values(size_t(n_ctx - 1 - n_ctx/2)*n_chunk);
     std::vector<float> p_diff_values(size_t(n_ctx - 1 - n_ctx/2)*n_chunk);
 


### PR DESCRIPTION
## Overview

This PR makes KLD baseline generation and candidate evaluation honor the batch
size requested with `--batch-size` (`-b`). `--ubatch-size` (`-ub`) continues to
control the internal physical split.

The KLD path currently applies a fixed 512 MiB cap to the number of full-vocab
F32 logits rows. This silently reduces the effective decode batch even when the
context and compute graph were configured for a larger value. For example, with
a vocabulary of 248320 tokens, `-b 2048 -ub 2048` is reduced to 540 rows:

```text
kl_divergence: computing over 9 chunks, n_ctx=32768, batch_size=540, n_seq=1
```

That is surprising when the batch size was explicitly requested and differs from the
KLD behavior in the corresponding llama.cpp b10830 base. The KLD implementation
already processes data block by block, so honoring `-b` does not restore the
context-wide logits retention of the older upstream implementation. The 512 MiB
row cap remains in place for ordinary perplexity calculation.

The change also sizes the compressed baseline block from the effective decode
batch and adds a plumbing regression test and memory guidance to the perplexity
README.

## Additional information

The existing batch-size setting is already the memory/performance control for
this path; users who need lower host-memory use can reduce `-b`. The additional
storage for retaining more full-vocab rows is host memory. For the tested
248320-token vocabulary, a batch size of 2048 requires approximately:

- 1940 MiB for the F32 logits block
- 970 MiB for the compressed baseline block
- 2910 MiB total block storage

This is about 2.1 GiB more host memory than the previous 540-row limit.

In the tested CUDA configuration (`-c 32768 -b 2048 -ub 2048 -fa on`, Q8_0 KV),
the backend-reported allocations were unchanged between the capped and patched
runs because the context had already reserved the graph for the requested batch:

```text
CUDA0 compute buffer size     = 2108.00 MiB
CUDA_Host compute buffer size = 208.34 MiB
```

This observation is specific to the tested configuration; other backends or
larger batch/ubatch settings may have different device-memory requirements.

Validation performed on Windows/CUDA with a Qwen3.8 27B model and 248320-token
vocabulary:

- `-c 32768 -b 2048 -ub 2048` now reports `batch_size=2048`
- patched BeeLlama and llama.cpp b10830 produced identical printed results
  against a b10830-generated baseline:
  - Mean PPL(Q): `7.026714 +/- 0.047518`
  - Mean PPL(base): `7.013139 +/- 0.047018`
  - Mean KLD: `0.007269 +/- 0.000738`
  - Same top p: `98.540 +/- 0.031 %`
- `test-perplexity-plumbing` passes

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI tools assisted with implementation review, test-result analysis, and drafting this PR description; the changes and reported results were reviewed and tested by the submitter.
